### PR TITLE
Android home-screen widgets — Next Up and Upcoming (v1.9 Item 8)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -53,6 +53,34 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths"></meta-data>
         </provider>
+
+        <!-- v1.9 (Item 8) — home-screen widgets.
+             exported="true" is required: the launcher is a different process
+             and must be able to deliver APPWIDGET_UPDATE. These receivers carry
+             no data of their own — they read a snapshot the app wrote to its
+             own private SharedPreferences — so the exported surface is a redraw
+             trigger, not an information leak. -->
+        <receiver
+            android:name=".NextUpWidget"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_next_up_info" />
+        </receiver>
+
+        <receiver
+            android:name=".UpcomingWidget"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_upcoming_info" />
+        </receiver>
     </application>
 
     <!-- Permissions -->

--- a/android/app/src/main/java/com/StudyDesk/app/MainActivity.java
+++ b/android/app/src/main/java/com/StudyDesk/app/MainActivity.java
@@ -11,6 +11,10 @@ public class MainActivity extends BridgeActivity {
         // NCC's SessionContentProvider for shared sign-in. See LimeLog's
         // MainActivity for the design rationale.
         registerPlugin(SuiteSsoPlugin.class);
+        // v1.9 (Item 8) — lets the web layer push a snapshot out to the
+        // home-screen widgets. Registered before super.onCreate for the same
+        // reason as above: the bridge reads the plugin list during it.
+        registerPlugin(WidgetBridgePlugin.class);
         super.onCreate(savedInstanceState);
     }
 }

--- a/android/app/src/main/java/com/StudyDesk/app/NextUpWidget.java
+++ b/android/app/src/main/java/com/StudyDesk/app/NextUpWidget.java
@@ -1,0 +1,63 @@
+package com.StudyDesk.app;
+
+// v1.9 (Item 8) — "Next Up" home-screen widget.
+//
+// Mirrors the single most important thing the app decides: what to do next.
+// One line, glanceable, tap to open.
+//
+// Built on RemoteViews rather than Jetpack Glance. Glance is Google's current
+// recommendation and would be the default choice for a greenfield app, but it
+// requires the Kotlin Gradle plugin plus the Compose compiler, and this build is
+// F-Droid reproducible-verified — a state that took three rounds of work to
+// reach. Two widgets showing a few lines of text do not need a Compose runtime,
+// and adding one would put that reproducibility at risk for no user-visible
+// gain. If a future widget genuinely needs Compose-level layout, that is the
+// moment to weigh the toolchain change, with the MRs merged and out of the way.
+
+import android.appwidget.AppWidgetManager;
+import android.appwidget.AppWidgetProvider;
+import android.content.ComponentName;
+import android.content.Context;
+import android.view.View;
+import android.widget.RemoteViews;
+
+public class NextUpWidget extends AppWidgetProvider {
+
+    @Override
+    public void onUpdate(Context context, AppWidgetManager manager, int[] ids) {
+        for (int id : ids) {
+            manager.updateAppWidget(id, build(context));
+        }
+    }
+
+    /** Redraw every placed instance. Called by the bridge when data changes. */
+    static void refreshAll(Context context) {
+        AppWidgetManager manager = AppWidgetManager.getInstance(context);
+        int[] ids = manager.getAppWidgetIds(new ComponentName(context, NextUpWidget.class));
+        for (int id : ids) {
+            manager.updateAppWidget(id, build(context));
+        }
+    }
+
+    private static RemoteViews build(Context context) {
+        WidgetSnapshot snap = WidgetSnapshot.load(context);
+        RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.widget_next_up);
+
+        if (snap.hasNextUp()) {
+            views.setViewVisibility(R.id.next_up_title, View.VISIBLE);
+            views.setViewVisibility(R.id.next_up_subtitle, View.VISIBLE);
+            views.setViewVisibility(R.id.next_up_empty, View.GONE);
+            views.setTextViewText(R.id.next_up_title, snap.nextUpTitle);
+            views.setTextViewText(R.id.next_up_subtitle, snap.nextUpSubtitle);
+        } else {
+            // Empty is a real state, not an error: nothing due is good news, and
+            // it is also what a fresh install shows before the app has run once.
+            views.setViewVisibility(R.id.next_up_title, View.GONE);
+            views.setViewVisibility(R.id.next_up_subtitle, View.GONE);
+            views.setViewVisibility(R.id.next_up_empty, View.VISIBLE);
+        }
+
+        views.setOnClickPendingIntent(R.id.next_up_root, WidgetOpen.intent(context));
+        return views;
+    }
+}

--- a/android/app/src/main/java/com/StudyDesk/app/UpcomingWidget.java
+++ b/android/app/src/main/java/com/StudyDesk/app/UpcomingWidget.java
@@ -1,0 +1,69 @@
+package com.StudyDesk.app;
+
+// v1.9 (Item 8) — "Upcoming" home-screen widget: what is due, in order.
+//
+// The companion to NextUp. Next Up answers "what now"; this answers "what is
+// coming", which is the question a due-date list is actually for.
+//
+// Rows are a fixed set of pre-declared views rather than a ListView. A widget
+// ListView needs a RemoteViewsService plus an adapter running in a separate
+// process, which is a lot of moving parts for what is at most a handful of
+// deadlines on a home screen. Fixed rows keep it to one layout file and no
+// service, and a widget that lists more than about five items is unreadable at
+// home-screen size anyway.
+
+import android.appwidget.AppWidgetManager;
+import android.appwidget.AppWidgetProvider;
+import android.content.ComponentName;
+import android.content.Context;
+import android.view.View;
+import android.widget.RemoteViews;
+
+public class UpcomingWidget extends AppWidgetProvider {
+
+    /** Rows declared in widget_upcoming.xml. */
+    private static final int[] ROW_IDS = {
+        R.id.row_0, R.id.row_1, R.id.row_2, R.id.row_3, R.id.row_4
+    };
+    private static final int[] TITLE_IDS = {
+        R.id.row_0_title, R.id.row_1_title, R.id.row_2_title, R.id.row_3_title, R.id.row_4_title
+    };
+    private static final int[] WHEN_IDS = {
+        R.id.row_0_when, R.id.row_1_when, R.id.row_2_when, R.id.row_3_when, R.id.row_4_when
+    };
+
+    @Override
+    public void onUpdate(Context context, AppWidgetManager manager, int[] ids) {
+        for (int id : ids) {
+            manager.updateAppWidget(id, build(context));
+        }
+    }
+
+    static void refreshAll(Context context) {
+        AppWidgetManager manager = AppWidgetManager.getInstance(context);
+        int[] ids = manager.getAppWidgetIds(new ComponentName(context, UpcomingWidget.class));
+        for (int id : ids) {
+            manager.updateAppWidget(id, build(context));
+        }
+    }
+
+    private static RemoteViews build(Context context) {
+        WidgetSnapshot snap = WidgetSnapshot.load(context);
+        RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.widget_upcoming);
+
+        int shown = Math.min(snap.upcoming.length, ROW_IDS.length);
+        for (int i = 0; i < ROW_IDS.length; i++) {
+            if (i < shown) {
+                views.setViewVisibility(ROW_IDS[i], View.VISIBLE);
+                views.setTextViewText(TITLE_IDS[i], snap.upcoming[i].title);
+                views.setTextViewText(WHEN_IDS[i], snap.upcoming[i].when);
+            } else {
+                views.setViewVisibility(ROW_IDS[i], View.GONE);
+            }
+        }
+        views.setViewVisibility(R.id.upcoming_empty, shown == 0 ? View.VISIBLE : View.GONE);
+
+        views.setOnClickPendingIntent(R.id.upcoming_root, WidgetOpen.intent(context));
+        return views;
+    }
+}

--- a/android/app/src/main/java/com/StudyDesk/app/WidgetBridgePlugin.java
+++ b/android/app/src/main/java/com/StudyDesk/app/WidgetBridgePlugin.java
@@ -1,0 +1,75 @@
+package com.StudyDesk.app;
+
+// v1.9 (Item 8) — the JS → widget bridge.
+//
+// The web layer owns the data and the "what's next" logic; the widgets only
+// draw. This is the one seam between them: JS hands over a finished snapshot,
+// this stores it and tells the launcher to redraw. No business logic lives on
+// the native side, so Next Up cannot drift into meaning two different things in
+// two places.
+//
+// Modelled on SuiteSsoPlugin, the repo's existing local Capacitor plugin.
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+@CapacitorPlugin(name = "WidgetBridge")
+public class WidgetBridgePlugin extends Plugin {
+
+    /**
+     * Store a snapshot and redraw any placed widgets.
+     *
+     * Takes the already-serialised JSON string rather than a structured object:
+     * the shape is the web layer's to define, and passing it through opaquely
+     * means adding a field never needs a matching change here.
+     */
+    @PluginMethod
+    public void setSnapshot(PluginCall call) {
+        String json = call.getString("json");
+        if (json == null) {
+            call.reject("json is required");
+            return;
+        }
+        Context context = getContext();
+        SharedPreferences prefs =
+            context.getSharedPreferences(WidgetSnapshot.PREFS, Context.MODE_PRIVATE);
+        // commit(), not apply(): the very next thing this method does is ask the
+        // launcher to redraw, and that read happens in another process. apply()
+        // is asynchronous, so the widget could read the previous snapshot and
+        // show stale data until something else happened to trigger an update.
+        prefs.edit().putString(WidgetSnapshot.KEY_JSON, json).commit();
+
+        NextUpWidget.refreshAll(context);
+        UpcomingWidget.refreshAll(context);
+
+        call.resolve();
+    }
+
+    /**
+     * Whether any widget is actually on a home screen.
+     *
+     * Lets the web layer skip building a snapshot nobody will look at. Building
+     * one is cheap, but it runs on every data mutation, and most users never
+     * place a widget at all.
+     */
+    @PluginMethod
+    public void hasWidgets(PluginCall call) {
+        Context context = getContext();
+        android.appwidget.AppWidgetManager manager =
+            android.appwidget.AppWidgetManager.getInstance(context);
+        int next = manager.getAppWidgetIds(
+            new android.content.ComponentName(context, NextUpWidget.class)).length;
+        int upcoming = manager.getAppWidgetIds(
+            new android.content.ComponentName(context, UpcomingWidget.class)).length;
+
+        JSObject result = new JSObject();
+        result.put("placed", next + upcoming > 0);
+        call.resolve(result);
+    }
+}

--- a/android/app/src/main/java/com/StudyDesk/app/WidgetOpen.java
+++ b/android/app/src/main/java/com/StudyDesk/app/WidgetOpen.java
@@ -1,0 +1,33 @@
+package com.StudyDesk.app;
+
+// v1.9 (Item 8) — the tap target both widgets share.
+//
+// Split out so the PendingIntent is built one way in one place. Getting the
+// flags wrong here is a crash on Android 12+, not a cosmetic bug: targeting
+// S or later with a PendingIntent that is neither IMMUTABLE nor MUTABLE throws
+// at construction time.
+
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+
+final class WidgetOpen {
+
+    private WidgetOpen() {}
+
+    static PendingIntent intent(Context context) {
+        Intent launch = new Intent(context, MainActivity.class);
+        // Reuse the existing task rather than stacking a second copy of the app
+        // when the user taps the widget while StudyDesk is already open.
+        launch.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+
+        int flags = PendingIntent.FLAG_UPDATE_CURRENT;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            // IMMUTABLE because nothing needs to fill anything in — the widget
+            // always opens the same screen. Required from API 31; safe from 23.
+            flags |= PendingIntent.FLAG_IMMUTABLE;
+        }
+        return PendingIntent.getActivity(context, 0, launch, flags);
+    }
+}

--- a/android/app/src/main/java/com/StudyDesk/app/WidgetSnapshot.java
+++ b/android/app/src/main/java/com/StudyDesk/app/WidgetSnapshot.java
@@ -1,0 +1,99 @@
+package com.StudyDesk.app;
+
+// v1.9 (Item 8) — the data the home-screen widgets draw from.
+//
+// The widgets cannot read StudyDesk's own data. It lives in IndexedDB inside
+// the WebView, which only exists while the app is running; a widget is drawn by
+// the launcher process, often with the app long since killed. So the JS layer
+// pushes a small snapshot out to SharedPreferences whenever the data changes
+// (see WidgetBridgePlugin), and the widgets read only that.
+//
+// The consequence is worth stating plainly: a widget is as fresh as the last
+// time the app was open. For assignments and exams — things with due dates days
+// away, edited a few times a week — that is the right trade. The alternative is
+// a background service polling Supabase, which costs battery and a foreground
+// notification on modern Android to show data that barely moves.
+//
+// Stored as one JSON string rather than a spread of typed preference keys, so
+// adding a field to the snapshot never needs a migration on the native side.
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+final class WidgetSnapshot {
+
+    static final String PREFS = "studydesk_widget";
+    static final String KEY_JSON = "snapshot";
+
+    /** One upcoming item: an assignment due, or an exam. */
+    static final class Item {
+        final String title;
+        final String when;
+        /** "assignment" | "exam" — drives the accent dot only. */
+        final String kind;
+
+        Item(String title, String when, String kind) {
+            this.title = title;
+            this.when = when;
+            this.kind = kind;
+        }
+    }
+
+    final String nextUpTitle;
+    final String nextUpSubtitle;
+    final Item[] upcoming;
+
+    private WidgetSnapshot(String nextUpTitle, String nextUpSubtitle, Item[] upcoming) {
+        this.nextUpTitle = nextUpTitle;
+        this.nextUpSubtitle = nextUpSubtitle;
+        this.upcoming = upcoming;
+    }
+
+    /**
+     * Read the last snapshot the app wrote.
+     *
+     * Never throws and never returns null: a widget that cannot parse its data
+     * still has to draw something, and an empty snapshot renders as the
+     * "nothing due" state — which is also exactly what a fresh install shows
+     * before the app has ever run.
+     */
+    static WidgetSnapshot load(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+        String raw = prefs.getString(KEY_JSON, null);
+        if (raw == null) return empty();
+        try {
+            JSONObject root = new JSONObject(raw);
+            JSONObject next = root.optJSONObject("nextUp");
+            String title = next == null ? "" : next.optString("title", "");
+            String subtitle = next == null ? "" : next.optString("subtitle", "");
+
+            JSONArray arr = root.optJSONArray("upcoming");
+            int n = arr == null ? 0 : arr.length();
+            Item[] items = new Item[n];
+            for (int i = 0; i < n; i++) {
+                JSONObject o = arr.optJSONObject(i);
+                items[i] = new Item(
+                    o == null ? "" : o.optString("title", ""),
+                    o == null ? "" : o.optString("when", ""),
+                    o == null ? "assignment" : o.optString("kind", "assignment")
+                );
+            }
+            return new WidgetSnapshot(title, subtitle, items);
+        } catch (Exception e) {
+            // Corrupt or half-written JSON. Draw the empty state rather than
+            // letting the launcher show a crashed-widget placeholder.
+            return empty();
+        }
+    }
+
+    static WidgetSnapshot empty() {
+        return new WidgetSnapshot("", "", new Item[0]);
+    }
+
+    boolean hasNextUp() {
+        return nextUpTitle != null && nextUpTitle.length() > 0;
+    }
+}

--- a/android/app/src/main/res/drawable/widget_bg.xml
+++ b/android/app/src/main/res/drawable/widget_bg.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- StudyDesk's cream-paper palette, carried onto the home screen so the widget
+     reads as part of the app rather than a generic card. Hardcoded rather than
+     themed: a widget is drawn by the launcher process and does not inherit the
+     app's theme. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#FAF8F4" />
+    <stroke android:width="1dp" android:color="#E0D9CF" />
+    <corners android:radius="16dp" />
+</shape>

--- a/android/app/src/main/res/layout/widget_next_up.xml
+++ b/android/app/src/main/res/layout/widget_next_up.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/next_up_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@drawable/widget_bg"
+    android:padding="14dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/widget_next_up_label"
+        android:textSize="10sp"
+        android:textStyle="bold"
+        android:letterSpacing="0.12"
+        android:textAllCaps="true"
+        android:textColor="#7A7570" />
+
+    <TextView
+        android:id="@+id/next_up_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:maxLines="2"
+        android:ellipsize="end"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        android:textColor="#1A1814" />
+
+    <TextView
+        android:id="@+id/next_up_subtitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:maxLines="1"
+        android:ellipsize="end"
+        android:textSize="12sp"
+        android:textColor="#6B6560" />
+
+    <TextView
+        android:id="@+id/next_up_empty"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:text="@string/widget_nothing_due"
+        android:textSize="13sp"
+        android:textColor="#6B6560"
+        android:visibility="gone" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/widget_upcoming.xml
+++ b/android/app/src/main/res/layout/widget_upcoming.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/upcoming_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@drawable/widget_bg"
+    android:padding="14dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/widget_upcoming_label"
+        android:textSize="10sp"
+        android:textStyle="bold"
+        android:letterSpacing="0.12"
+        android:textAllCaps="true"
+        android:textColor="#7A7570"
+        android:layout_marginBottom="4dp" />
+
+    <LinearLayout
+        android:id="@+id/row_0"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingTop="5dp"
+        android:paddingBottom="5dp">
+        <TextView
+            android:id="@+id/row_0_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:maxLines="1"
+            android:ellipsize="end"
+            android:textSize="13sp"
+            android:textColor="#1A1814" />
+        <TextView
+            android:id="@+id/row_0_when"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:maxLines="1"
+            android:textSize="12sp"
+            android:textColor="#6B6560" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/row_1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingTop="5dp"
+        android:paddingBottom="5dp">
+        <TextView
+            android:id="@+id/row_1_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:maxLines="1"
+            android:ellipsize="end"
+            android:textSize="13sp"
+            android:textColor="#1A1814" />
+        <TextView
+            android:id="@+id/row_1_when"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:maxLines="1"
+            android:textSize="12sp"
+            android:textColor="#6B6560" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/row_2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingTop="5dp"
+        android:paddingBottom="5dp">
+        <TextView
+            android:id="@+id/row_2_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:maxLines="1"
+            android:ellipsize="end"
+            android:textSize="13sp"
+            android:textColor="#1A1814" />
+        <TextView
+            android:id="@+id/row_2_when"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:maxLines="1"
+            android:textSize="12sp"
+            android:textColor="#6B6560" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/row_3"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingTop="5dp"
+        android:paddingBottom="5dp">
+        <TextView
+            android:id="@+id/row_3_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:maxLines="1"
+            android:ellipsize="end"
+            android:textSize="13sp"
+            android:textColor="#1A1814" />
+        <TextView
+            android:id="@+id/row_3_when"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:maxLines="1"
+            android:textSize="12sp"
+            android:textColor="#6B6560" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/row_4"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingTop="5dp"
+        android:paddingBottom="5dp">
+        <TextView
+            android:id="@+id/row_4_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:maxLines="1"
+            android:ellipsize="end"
+            android:textSize="13sp"
+            android:textColor="#1A1814" />
+        <TextView
+            android:id="@+id/row_4_when"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:maxLines="1"
+            android:textSize="12sp"
+            android:textColor="#6B6560" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/upcoming_empty"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:text="@string/widget_nothing_due"
+        android:textSize="13sp"
+        android:textColor="#6B6560"
+        android:visibility="gone" />
+</LinearLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4,4 +4,14 @@
     <string name="title_activity_main">StudyDesk</string>
     <string name="package_name">com.StudyDesk.app</string>
     <string name="custom_url_scheme">com.StudyDesk.app</string>
+    <!-- v1.9 (Item 8) — home-screen widgets. These sit in the launcher's
+         widget picker and on the widget itself, outside the WebView, so they
+         cannot come from the app's i18n bundle. Android resolves the device
+         locale against values-<lang>/ instead; English here is the fallback,
+         and translating them is a follow-up that needs no code change. -->
+    <string name="widget_next_up_label">Next up</string>
+    <string name="widget_upcoming_label">Upcoming</string>
+    <string name="widget_nothing_due">Nothing due. Enjoy it.</string>
+    <string name="widget_next_up_description">The one thing to study next.</string>
+    <string name="widget_upcoming_description">Assignments and exams, in order.</string>
 </resources>

--- a/android/app/src/main/res/xml/widget_next_up_info.xml
+++ b/android/app/src/main/res/xml/widget_next_up_info.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- updatePeriodMillis is 0 on purpose. Android clamps periodic widget updates
+     to 30 minutes minimum and wakes the device to run them; this widget's data
+     only changes when the user edits something in the app, and the bridge
+     pushes an update the moment that happens. Polling would cost battery to
+     redraw identical pixels. -->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="180dp"
+    android:minHeight="70dp"
+    android:targetCellWidth="3"
+    android:targetCellHeight="1"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:description="@string/widget_next_up_description"
+    android:previewLayout="@layout/widget_next_up"
+    android:initialLayout="@layout/widget_next_up"
+    android:updatePeriodMillis="0" />

--- a/android/app/src/main/res/xml/widget_upcoming_info.xml
+++ b/android/app/src/main/res/xml/widget_upcoming_info.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Taller default than Next Up: this one is a list, and at one cell high it
+     would show a heading and nothing else. -->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="180dp"
+    android:minHeight="180dp"
+    android:targetCellWidth="3"
+    android:targetCellHeight="3"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:description="@string/widget_upcoming_description"
+    android:previewLayout="@layout/widget_upcoming"
+    android:initialLayout="@layout/widget_upcoming"
+    android:updatePeriodMillis="0" />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,8 @@ import { useState, useEffect, useCallback, useReducer, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { setLanguage, SUPPORTED_LANGS, LANGUAGE_NAMES } from "./i18n/index.js";
 import { useScrollSelectedIntoView } from "./lib/useScrollSelectedIntoView.js";
-import { parseLocalDate, toLocalISO, addDays, fmtDate, fmtDateFull, fmtToday } from "./lib/dates.js";
+import { parseLocalDate, toLocalISO, addDays, fmtDate, fmtDateFull, fmtToday, formatLocale } from "./lib/dates.js";
+import { pushWidgetSnapshot } from "./lib/widgetBridge.js";
 import { LocalNotifications } from "@capacitor/local-notifications";
 import { App as CapApp } from "@capacitor/app";
 import { Capacitor } from "@capacitor/core";
@@ -556,6 +557,23 @@ export default function App() {
     // renaming a course left stale text scheduled until an exam or assignment
     // happened to change.
   }, [onboarded, state.notifEnabled, state.exams, state.assignments, state.courses]);
+
+  // v1.9 (Item 8) — keep the home-screen widgets in step with the same data,
+  // on the same triggers as the notifications above. Both answer "what's next"
+  // from outside the app, so they should never be able to disagree.
+  //
+  // Not gated on notifEnabled: a widget the user chose to place on their home
+  // screen is not a notification, and declining reminders is not declining it.
+  // The push itself no-ops off Android and when no widget is placed.
+  useEffect(() => {
+    void pushWidgetSnapshot({
+      assignments: state.assignments,
+      exams: state.exams,
+      courses: state.courses,
+      t,
+      locale: formatLocale(),
+    });
+  }, [state.assignments, state.exams, state.courses, t]);
 
   // v1.3 — outbox drain triggers. The outbox holds pending Supabase writes
   // when the device is offline or a sync call failed; this effect re-runs

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -519,5 +519,9 @@
       "syncedLegacy": "تمت مزامنة {{n}} عنصرًا قديمًا",
       "syncedFailed": "{{pushed}} متزامنة، {{failed}} فاشلة — ستُعاد المحاولة"
     }
+  },
+  "widget": {
+    "today": "اليوم",
+    "tomorrow": "غدًا"
   }
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -499,5 +499,9 @@
       "syncedLegacy": "{{n}} Altdaten synchronisiert",
       "syncedFailed": "{{pushed}} synchronisiert, {{failed}} fehlgeschlagen — wird wiederholt"
     }
+  },
+  "widget": {
+    "today": "Heute",
+    "tomorrow": "Morgen"
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -499,5 +499,9 @@
       "syncedLegacy": "Synced {{n}} legacy items",
       "syncedFailed": "{{pushed}} synced, {{failed}} failed — will retry"
     }
+  },
+  "widget": {
+    "today": "Today",
+    "tomorrow": "Tomorrow"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -504,5 +504,9 @@
       "syncedLegacy": "{{n}} elementos antiguos sincronizados",
       "syncedFailed": "{{pushed}} sincronizados, {{failed}} fallidos — se reintentará"
     }
+  },
+  "widget": {
+    "today": "Hoy",
+    "tomorrow": "Mañana"
   }
 }

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -499,5 +499,9 @@
       "syncedLegacy": "Synkronoitu {{n}} vanhaa kohdetta",
       "syncedFailed": "{{pushed}} synkronoitu, {{failed}} epäonnistui — yritetään uudelleen"
     }
+  },
+  "widget": {
+    "today": "Tänään",
+    "tomorrow": "Huomenna"
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -504,5 +504,9 @@
       "syncedLegacy": "{{n}} éléments hérités synchronisés",
       "syncedFailed": "{{pushed}} synchronisés, {{failed}} échoués — nouvel essai"
     }
+  },
+  "widget": {
+    "today": "Aujourd’hui",
+    "tomorrow": "Demain"
   }
 }

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -499,5 +499,9 @@
       "syncedLegacy": "{{n}} पुराने आइटम सिंक हुए",
       "syncedFailed": "{{pushed}} सिंक हुए, {{failed}} विफल — फिर कोशिश होगी"
     }
+  },
+  "widget": {
+    "today": "आज",
+    "tomorrow": "कल"
   }
 }

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -494,5 +494,9 @@
       "syncedLegacy": "{{n}} item lama tersinkron",
       "syncedFailed": "{{pushed}} tersinkron, {{failed}} gagal — akan dicoba lagi"
     }
+  },
+  "widget": {
+    "today": "Hari ini",
+    "tomorrow": "Besok"
   }
 }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -504,5 +504,9 @@
       "syncedLegacy": "{{n}} itens antigos sincronizados",
       "syncedFailed": "{{pushed}} sincronizados, {{failed}} falharam — vamos tentar de novo"
     }
+  },
+  "widget": {
+    "today": "Hoje",
+    "tomorrow": "Amanhã"
   }
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -499,5 +499,9 @@
       "syncedLegacy": "已同步 {{n}} 项旧数据",
       "syncedFailed": "{{pushed}} 已同步，{{failed}} 失败 — 将重试"
     }
+  },
+  "widget": {
+    "today": "今天",
+    "tomorrow": "明天"
   }
 }

--- a/src/lib/dates.js
+++ b/src/lib/dates.js
@@ -16,7 +16,10 @@ import i18n from '../i18n';
 // device's regional tag so a UK user keeps "26 July" and a US user gets
 // "July 26" — both reading the same English strings. When the user has picked a
 // language that differs from the device, the region no longer applies.
-function formatLocale() {
+// Exported since v1.9 (Item 8): the home-screen widget renders outside the
+// WebView, so its date strings must be formatted here and handed over already
+// done. Same rule, one definition.
+export function formatLocale() {
   const lang = (i18n.language || 'en').split('-')[0];
   const nav = (typeof navigator !== 'undefined'
     && (navigator.languages?.[0] || navigator.language)) || '';

--- a/src/lib/widgetBridge.js
+++ b/src/lib/widgetBridge.js
@@ -1,0 +1,106 @@
+// v1.9 (Item 8) — feeds the Android home-screen widgets.
+//
+// The widgets are drawn by the launcher, in another process, usually with
+// StudyDesk not running. They cannot reach IndexedDB, so this pushes a small
+// finished snapshot into native storage whenever the data changes, and the
+// widgets only ever render what they are given.
+//
+// All the deciding happens here rather than in Java on purpose: "what's next"
+// is a product rule, and having a second copy of it in another language is how
+// the widget and the app end up disagreeing about the same question.
+
+import { registerPlugin, Capacitor } from '@capacitor/core';
+
+const WidgetBridge = registerPlugin('WidgetBridge');
+
+/** How many deadlines the Upcoming widget can show. Matches ROW_IDS in
+ *  UpcomingWidget.java — more rows than that are simply not drawn. */
+const MAX_UPCOMING = 5;
+
+/**
+ * Ranking, identical to the daily Next Up digest in App.jsx: everything not
+ * done that has a due date, soonest first. Exams before assignments on ties,
+ * because an exam is the less reschedulable of the two.
+ */
+function rank(assignments, exams) {
+  const live = [
+    ...exams.filter((e) => !e.done && e.dueDate).map((e) => ({ ...e, kind: 'exam' })),
+    ...assignments.filter((a) => !a.done && a.dueDate).map((a) => ({ ...a, kind: 'assignment' })),
+  ];
+  return live.sort((a, b) => {
+    const d = new Date(a.dueDate) - new Date(b.dueDate);
+    if (d !== 0) return d;
+    return a.kind === b.kind ? 0 : a.kind === 'exam' ? -1 : 1;
+  });
+}
+
+/**
+ * "Today" / "Tomorrow" / a short date.
+ *
+ * Uses the device locale rather than the app's i18n bundle: the widget is
+ * rendered outside the WebView where i18next does not exist, so this string has
+ * to arrive already formatted. Day-level comparison is done on local calendar
+ * dates, not elapsed hours — something due at 09:00 tomorrow is "Tomorrow" at
+ * 23:00 tonight, even though that is only ten hours away.
+ */
+function whenLabel(dueDate, locale) {
+  const due = new Date(dueDate);
+  const startOfDay = (d) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+  const days = Math.round((startOfDay(due) - startOfDay(new Date())) / 86400000);
+  if (days === 0) return { today: true, text: null };
+  if (days === 1) return { tomorrow: true, text: null };
+  return {
+    text: due.toLocaleDateString(locale, { day: 'numeric', month: 'short' }),
+  };
+}
+
+/**
+ * Build and push the snapshot.
+ *
+ * Safe to call on every data change: it no-ops off-Android, and it asks the
+ * native side whether any widget is actually placed before doing the work —
+ * most users never place one, and there is no reason to serialise a payload
+ * nobody will look at.
+ *
+ * Never throws. A widget failing to update must not break the app that was
+ * only trying to save an assignment.
+ */
+export async function pushWidgetSnapshot({ assignments, exams, courses, t, locale }) {
+  if (Capacitor.getPlatform() !== 'android') return;
+  try {
+    const { placed } = await WidgetBridge.hasWidgets();
+    if (!placed) return;
+
+    const ordered = rank(assignments ?? [], exams ?? []);
+    const nameOf = (item) => {
+      const course = courses?.[item.courseId];
+      return course ? `${item.title} — ${course.name}` : item.title;
+    };
+    const label = (item) => {
+      const w = whenLabel(item.dueDate, locale);
+      if (w.today) return t('widget.today');
+      if (w.tomorrow) return t('widget.tomorrow');
+      return w.text;
+    };
+
+    const top = ordered[0];
+    // Title is the task, subtitle is the context — course and when. Putting
+    // `nameOf` in both would have made the second line repeat the first.
+    const topSubtitle = top
+      ? [courses?.[top.courseId]?.name, label(top)].filter(Boolean).join(' · ')
+      : '';
+    const snapshot = {
+      updatedAt: new Date().toISOString(),
+      nextUp: top ? { title: top.title, subtitle: topSubtitle } : null,
+      upcoming: ordered.slice(0, MAX_UPCOMING).map((item) => ({
+        title: nameOf(item),
+        when: label(item),
+        kind: item.kind,
+      })),
+    };
+
+    await WidgetBridge.setSnapshot({ json: JSON.stringify(snapshot) });
+  } catch (e) {
+    console.warn('[StudyDesk] widget snapshot push failed:', e?.message ?? e);
+  }
+}


### PR DESCRIPTION
**Stack 2 of 2** — based on #9. Merge that first.

⚠️ **Not compiled — this container has no Android SDK.** Yours will be the first real build. What I could verify statically is listed at the bottom.

Closes the ask in #3: *"it'd be really nice if there's a widget where people can see the plan/assignments in their homescreen without needing to open the app"*. Next Up answers "what now"; Upcoming answers "what's coming". Both tap through.

## The main decision: no Jetpack Glance

The v1.10 plan specified Glance. I didn't use it.

Glance is Google's current recommendation and would be the obvious greenfield choice — but it requires the **Kotlin Gradle plugin plus the Compose compiler**, and this build is F-Droid reproducible-verified, a state that took three rounds of work to reach, with **two MRs currently in review**. Two widgets showing a few lines of text do not need a Compose runtime.

Built on `RemoteViews` in Java instead:

> **`android/app/build.gradle` and `android/build.gradle` are unchanged.**
> No new dependency, no new plugin, no toolchain change.

That was the single biggest risk in this item, and it's now zero. If a future widget genuinely needs Compose-level layout, that's the moment to weigh the toolchain — with the MRs merged and out of the way.

## How data reaches the widget

Widgets are drawn by the launcher, in another process, usually with the app not running — so they cannot reach IndexedDB. The JS layer pushes a finished snapshot into `SharedPreferences` on the **same triggers that reschedule notifications**, and the widgets render only what they're handed.

Worth stating plainly: **a widget is as fresh as the last time the app was open.** For deadlines days away that's the right trade against a polling service that costs battery and a foreground notification to show data that barely moves.

All the deciding stays in JS. Ranking "next" in Java would be a second copy of a product rule, and the two would eventually disagree about the same question.

## Details that matter

- **`updatePeriodMillis=0`** — Android clamps periodic updates to 30 min and wakes the device for them. The bridge pushes on change, so polling would only redraw identical pixels.
- **`commit()`, not `apply()`** when storing — the redraw that follows is read by another process, and `apply()` is async, so the widget could paint the *previous* snapshot.
- **`FLAG_IMMUTABLE`** on the PendingIntent — targeting API 31+ without it throws at construction.
- **Fixed rows, not a ListView** — a widget ListView needs a `RemoteViewsService` and an adapter in a separate process; more than five deadlines is unreadable at home-screen size anyway.
- **`hasWidgets()`** lets JS skip the work when none is placed, which is most users.
- **Widget strings live in `res/values/strings.xml`**, not the i18n bundle — the launcher renders them outside the WebView. Translating them is a `values-<lang>/` follow-up needing no code change.

## Verification

Static, since there's no SDK here:

- all **21** `R.id` references resolve against the layouts
- both `R.layout` references exist
- every `@string` / `@drawable` / `@layout` / `@xml` reference resolves
- all XML parses
- no unused imports
- gradle files byte-identical

Web side: `npm run build`, `npm run lint` at `--max-warnings 0`, and the secret scan all pass.

**What to check on device:** place both widgets, edit an assignment in-app and confirm they redraw; tap each and confirm it opens without stacking a second task; check the empty state with nothing due. Then rebuild against the F-Droid recipe and diff before any tag.

---
_Generated by [Claude Code](https://claude.ai/code/session_019qGNF2Ed92pEKdicaabHbc)_