### PR TITLE
chore(web): vercel.json build settings for the desktop web edition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,8 @@ finalize.ps1
 android/app/src/main/assets/public/
 android/app/src/main/assets/capacitor.config.json
 android/app/src/main/assets/capacitor.plugins.json
+
+# Vercel CLI local project link (project/org ids, machine-local)
+.vercel
+
+.vercel

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist"
+}


### PR DESCRIPTION
Adds `vercel.json` so the Vercel project builds correctly as a Vite app.

The project was created with framework preset "Other", which resolves the output directory to `public` or `.` and would serve nothing for a Vite build. Declaring framework/build/output in-repo keeps it correct rather than as dashboard state.

No rewrites needed (unlike NCC): StudyDesk makes zero raw `fetch(` calls — everything goes through supabase-js, which sends proper CORS headers. No catch-all SPA rewrite either: no router, view state lives in the reducer.

Verified live at https://studydesk.limecore.dev — build serves correctly (978 kB JS, matches the measured build).