### PR TITLE
fix(v1.10): app blanked on first paint in production builds

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -851,22 +851,11 @@ export default function App() {
     try { return localStorage.getItem("studydesk-onboarded") === "1"; } catch { return false; }
   });
   // v1.10 - ask the ACCOUNT whether onboarding is already done, not just this
-  // device. Gated so a signed-in user never sees a frame of the wizard before
-  // the answer lands; a guest or signed-out user resolves immediately, because
-  // there is no account to ask.
+  // device. The effect that does the asking lives further down, immediately
+  // after `session` is declared -- it reads `session`, and a dependency array
+  // is evaluated during render, so up here it referenced the binding before
+  // its useState had run.
   const [onboardChecked, setOnboardChecked] = useState(false);
-  useEffect(() => {
-    if (session === undefined) return;   // auth still resolving
-    if (!session) { setOnboardChecked(true); return; }
-    let cancelled = false;
-    setOnboardChecked(false);
-    hydrateOnboardedFromCloud().then((done) => {
-      if (cancelled) return;
-      if (done) setOnboarded(true);
-      setOnboardChecked(true);
-    });
-    return () => { cancelled = true; };
-  }, [session]);
   useEffect(() => {
     try { localStorage.setItem("studydesk-v1", JSON.stringify({
       courses:state.courses,
@@ -1117,6 +1106,33 @@ export default function App() {
   // are already session-gated, so this is a pure UI bypass — no other code
   // changes needed). When the user signs in or signs out, the flag is cleared.
   const [guest, setGuest] = useState(() => isGuestMode());
+
+  // v1.10 - the account-level onboarding check. Declared HERE, below `session`,
+  // rather than beside the `onboardChecked` state it drives: the dependency
+  // array `[session]` is evaluated on every render, so with this block above
+  // `const [session, ...] = useState(...)` it read `session` inside its
+  // temporal dead zone and threw "Cannot access 'session' before
+  // initialization", blanking the app on first paint.
+  //
+  // That failure was invisible to `npm run build` and to eslint, and did not
+  // reproduce under `npm run dev` -- only a production preview of the built
+  // bundle showed it. Keep this effect below the declaration.
+  //
+  // Gated so a signed-in user never sees a frame of the wizard before the
+  // answer lands; a guest or signed-out user resolves immediately, because
+  // there is no account to ask.
+  useEffect(() => {
+    if (session === undefined) return;   // auth still resolving
+    if (!session) { setOnboardChecked(true); return; }
+    let cancelled = false;
+    setOnboardChecked(false);
+    hydrateOnboardedFromCloud().then((done) => {
+      if (cancelled) return;
+      if (done) setOnboarded(true);
+      setOnboardChecked(true);
+    });
+    return () => { cancelled = true; };
+  }, [session]);
   useEffect(() => {
     let cancelled = false;
     (async () => {


### PR DESCRIPTION
Production hotfix. `studydesk.limecore.dev` is currently serving a blank page.

## What is broken

Every production build of 1.10.0 — web, APK and desktop installer all wrap the same `dist/` — throws during first render and paints nothing:

```
ReferenceError: Cannot access 'session' before initialization
```

## Cause

The account-level onboarding effect added in the v1.10 onboarding work sat beside the `onboardChecked` state it drives, ~250 lines above `const [session, setSession] = useState(undefined)`. A dependency array is evaluated on every render, so `[session]` read the binding inside its temporal dead zone.

Moving the effect below the declaration is the entire fix. The effect body is unchanged.

## Why it reached production

- `npm run build` compiles it without complaint.
- `eslint --max-warnings 0` does not flag it.
- It does **not** reproduce under `npm run dev`.

It only appears in a production preview of the built bundle, which the release gates did not include. The stale-asset gate proves the APK carries the current bundle; it cannot prove that bundle runs.

## Verification

- Clean rebuild emits `index-C-4XHNpt.js` (the broken bundle now live is `index-VU8lzrWO.js`).
- Production preview of that build renders the auth screen with a clean console.
- Release APK contains `index-C-4XHNpt.js`, does not contain the broken bundle, matches `dist/`, signed with cert `27e17d1f…`, versionCode 19 / 1.10.0.
- Desktop `app.asar` confirmed to carry the fixed bundle.
- NCC and LimeLog were checked for the same mistake — both declare their session binding above the equivalent effect, and both production builds boot clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)