### PR TITLE
v1.11: Vercel Web Analytics (web build only)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,4 +33,12 @@ export default defineConfig([
       'react-hooks/static-components': 'warn',
     },
   },
+  {
+    // Vite's own config runs in Node, not the browser — it reads process.env
+    // to decide the build-time web-analytics flag (see src/lib/webAnalytics.js).
+    // Without this it inherits the browser globals above and `process` reads as
+    // undefined.
+    files: ['vite.config.js'],
+    languageOptions: { globals: globals.node },
+  },
 ])

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "studydesk",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "studydesk",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor/android": "^8.2.0",
@@ -17,6 +17,7 @@
         "@capacitor/local-notifications": "^8.0.2",
         "@capacitor/preferences": "^8.0.1",
         "@supabase/supabase-js": "^2.106.0",
+        "@vercel/analytics": "^2.0.1",
         "i18next": "^23.16.8",
         "lucide-react": "^0.414.0",
         "react": "^19.2.4",
@@ -2918,6 +2919,48 @@
       "resolved": "https://registry.npmjs.org/@types/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==",
       "license": "MIT"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.4",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@capacitor/local-notifications": "^8.0.2",
     "@capacitor/preferences": "^8.0.1",
     "@supabase/supabase-js": "^2.106.0",
+    "@vercel/analytics": "^2.0.1",
     "i18next": "^23.16.8",
     "lucide-react": "^0.414.0",
     "react": "^19.2.4",

--- a/src/lib/webAnalytics.js
+++ b/src/lib/webAnalytics.js
@@ -1,0 +1,32 @@
+// Vercel Web Analytics — web deployment only, compiled out of every other build.
+//
+// WHY THE GATE IS AT BUILD TIME AND NOT RUNTIME
+//
+// This is the same bundle `cap sync` copies into the Android APK that F-Droid
+// builds and redistributes. A runtime check (`if (!isNative)`) would stop the
+// tracker from *running* there, but the library would still sit inside the
+// APK — and `@vercel/analytics` does not declare `sideEffects: false`, so
+// Rollup will not tree-shake a static import even behind a branch it can prove
+// is dead. A dynamic import behind a compile-time constant does get dropped:
+// Vite replaces the flag with a literal, the early return becomes
+// unconditional, the rest is unreachable, and the import() and its chunk go
+// with it. Checked rather than assumed, on every build:
+//
+//   npm run build && grep -ri "_vercel/insights" dist/   # expect no matches
+//
+// The flag comes from `process.env.VERCEL` in vite.config.js, which Vercel
+// sets on every build it runs. Nothing needs configuring by hand, and no
+// local, Electron-desktop or F-Droid build can switch it on by accident.
+//
+// The tracker is also undeclared in our F-Droid recipe (`AntiFeatures` lists
+// only NonFreeNet). linsui already caught two undisclosed hosts on !41550;
+// shipping this one would be the same mistake with a review step that no
+// longer exists, since AutoUpdateMode: Version publishes without one.
+export function initWebAnalytics() {
+  if (!import.meta.env.VITE_WEB_ANALYTICS) return;
+  import('@vercel/analytics')
+    .then(({ inject }) => inject())
+    .catch(() => {
+      // Analytics must never be why the app fails to start.
+    });
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,10 @@ import './i18n'
 import './index.css'
 import App from './App.jsx'
 import { ConfirmProvider } from './lib/ConfirmDialog.jsx'
+import { initWebAnalytics } from './lib/webAnalytics.js'
+
+// No-op unless this bundle was built by Vercel — see webAnalytics.js.
+initWebAnalytics()
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,4 +5,11 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   base: './',
+  // See src/lib/webAnalytics.js for why this is a build-time flag rather than
+  // a runtime check. `VERCEL` is set by Vercel on every build it runs, and is
+  // absent locally, in the Electron desktop build, and on F-Droid's builder —
+  // so the analytics import is compiled out of all three.
+  define: {
+    'import.meta.env.VITE_WEB_ANALYTICS': JSON.stringify(process.env.VERCEL === '1'),
+  },
 })


### PR DESCRIPTION
Promotes the analytics work to `main` so the production Vercel deploy picks it up.

Delta is exactly one change: `@vercel/analytics`, gated at build time on `process.env.VERCEL` so it is compiled out of the Android/F-Droid and Electron desktop bundles. Verified the native build adds zero bytes (bundle hash unchanged) and the Vercel build emits the analytics chunk. Full reasoning in #22.

Remaining step is outside the repo: Web Analytics must be enabled for the project in the Vercel dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)