### PR TITLE
v1.11: desktop glance widget (+ stable app origin)

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,29 +1,70 @@
 // Electron shell for StudyDesk's desktop edition. Wraps the existing static
 // Vite build (dist/) in a real installable Windows window rather than
-// "download a zip, open index.html yourself." Ported from Nexus-Dashboard's
-// electron/main.cjs — same underlying problem (SPA served as a native
-// window), same fix, kept in lockstep across both apps.
+// "download a zip, open index.html yourself." Kept in lockstep with
+// Nexus-Dashboard's electron/main.cjs — same underlying problem (SPA served as
+// a native window), same fix.
 //
-// Serves dist/ over a local HTTP server instead of loading file:// directly.
-// StudyDesk's vite.config.js already sets `base: './'` (relative asset
-// paths), so file:// would likely work for the current build — but the
-// embedded server also gives SPA-fallback routing for free and keeps this
-// shell identical to NCC's proven-working one, so it's the safer default
-// even though StudyDesk has no client-side router today.
+// ── Why a custom scheme and not http://127.0.0.1 (v1.11, forced-logout bug) ──
+//
+// This previously ran a local static server on `server.listen(0, ...)`, which
+// asks the OS for a RANDOM free port, and loaded `http://127.0.0.1:<port>/`.
+// The page therefore had a different ORIGIN on every single launch, and
+// localStorage — where supabase-js persists the session on non-Capacitor
+// platforms (src/lib/supabase.js passes `storage: undefined` off-native, i.e.
+// the default) — is partitioned per origin. So every launch opened an empty
+// storage bucket, the stored session was unreachable, and the user had to sign
+// in again. It looked like "my session expired"; nothing had expired at all.
+//
+// NCC diagnosed and fixed this in v1.10; the fix was never ported here, so
+// StudyDesk desktop kept the bug for a release longer. Confirmed on this
+// machine before changing anything: NCC's Local Storage holds both an old
+// `127.0.0.1:62320` bucket and the current `nexus://app` one, while
+// StudyDesk's still holds only a random-port `127.0.0.1:62769`.
+//
+// A fixed port would restore a stable origin but reintroduces the same class
+// of bug the moment that port is taken and the code falls back to another one.
+// A registered scheme has no port to collide, so the origin is stable by
+// construction. `secure: true` also keeps the page a secure context, which
+// supabase-js's PKCE flow needs for crypto.subtle.
+//
+// Two consequences worth knowing:
+//   - `studydesk://app/` is the app's web origin now. Any Supabase redirect-URL
+//     allowlist entry for the desktop build must use it — the old random-port
+//     127.0.0.1 URLs could never have been allowlisted, which is why OAuth was
+//     never usable here and email sign-in is the desktop path.
+//   - The one-time cost of moving origin is that whatever sat in the old
+//     random-port bucket is orphaned. Nothing is lost that wasn't already being
+//     lost on every launch.
+//
+// The static server is gone entirely rather than kept alongside: it existed to
+// provide SPA-fallback routing, and `resolveRequest` below does that directly.
 'use strict';
 
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, protocol, net } = require('electron');
 const path = require('node:path');
-const http = require('node:http');
 const fs = require('node:fs');
+const { pathToFileURL } = require('node:url');
 
 const DIST_DIR = path.join(__dirname, '..', 'dist');
 const ICON_PATH = path.join(__dirname, '..', 'resources', 'icon.ico');
 
+const SCHEME = 'studydesk';
+const APP_ORIGIN = `${SCHEME}://app`;
+
+// Must run before app.whenReady(). `standard` gives the scheme normal URL
+// parsing (host + path); `secure` grants secure-context powers (crypto.subtle,
+// and storage that isn't treated as third-party).
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: SCHEME,
+    privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true },
+  },
+]);
+
 // File-based diagnostics — packaged GUI Electron apps have no attached
-// console, so a launch failure is otherwise silently invisible. Carried
-// over from the NCC shell after that exact failure mode showed up there
-// during verification.
+// console, so a launch failure is otherwise silently invisible. Carried over
+// from the NCC shell after that exact failure mode showed up there during
+// verification.
 const LOG_PATH = path.join(app.getPath('userData'), 'main.log');
 function log(line) {
   try {
@@ -48,47 +89,45 @@ const MIME_TYPES = {
   '.ico': 'image/x-icon',
 };
 
-// Minimal static file server — no extra dependency, no network exposure
-// (bound to 127.0.0.1 only). SPA fallback: any path that doesn't resolve to
-// a real file under dist/ serves index.html.
-function startStaticServer() {
-  return new Promise((resolve, reject) => {
-    const server = http.createServer((req, res) => {
-      let urlPath = decodeURIComponent(req.url.split('?')[0]);
-      let filePath = path.join(DIST_DIR, urlPath);
+// Resolve a request URL to a real file under dist/, with the same SPA fallback
+// the old static server had: anything that isn't a real file serves index.html.
+function resolveRequest(requestUrl) {
+  const { pathname } = new URL(requestUrl);
+  const filePath = path.join(DIST_DIR, decodeURIComponent(pathname));
 
-      // Guard against path traversal escaping dist/.
-      if (!filePath.startsWith(DIST_DIR)) {
-        res.writeHead(403);
-        res.end();
-        return;
-      }
+  // Guard against path traversal escaping dist/. path.join has already
+  // normalised away `..`, so this compares the resolved result.
+  if (filePath !== DIST_DIR && !filePath.startsWith(DIST_DIR + path.sep)) return null;
 
-      fs.stat(filePath, (err, stats) => {
-        if (err || !stats.isFile()) {
-          filePath = path.join(DIST_DIR, 'index.html');
-        }
-        const ext = path.extname(filePath);
-        res.writeHead(200, { 'Content-Type': MIME_TYPES[ext] ?? 'application/octet-stream' });
-        fs.createReadStream(filePath).pipe(res);
-      });
+  try {
+    if (fs.statSync(filePath).isFile()) return filePath;
+  } catch {
+    // Falls through to the SPA entry point below.
+  }
+  return path.join(DIST_DIR, 'index.html');
+}
+
+function registerProtocolHandler() {
+  protocol.handle(SCHEME, async (request) => {
+    const filePath = resolveRequest(request.url);
+    if (!filePath) return new Response('Forbidden', { status: 403 });
+
+    const response = await net.fetch(pathToFileURL(filePath).toString());
+    // Set Content-Type explicitly rather than trusting inference — a wrong or
+    // missing type on the module scripts is a blank window with no error.
+    return new Response(response.body, {
+      status: 200,
+      headers: {
+        'Content-Type': MIME_TYPES[path.extname(filePath)] ?? 'application/octet-stream',
+      },
     });
-
-    server.listen(0, '127.0.0.1', () => {
-      const { port } = server.address();
-      resolve({ server, port });
-    });
-    server.on('error', reject);
   });
 }
 
 let mainWindow = null;
 
-async function createWindow() {
+function createWindow() {
   try {
-    const { port } = await startStaticServer();
-    log(`static server listening on 127.0.0.1:${port}`);
-
     mainWindow = new BrowserWindow({
       width: 1440,
       height: 900,
@@ -96,7 +135,10 @@ async function createWindow() {
       minHeight: 700,
       icon: ICON_PATH,
       autoHideMenuBar: true,
-      backgroundColor: '#0d1117', // matches the app's dark theme surface, avoids a white flash on load
+      // StudyDesk's --bg (src/styles/base.css). Was NCC's #0d1117 for as long
+      // as this shell has existed — a copy-paste from the app it was ported
+      // from, which flashed dark before a cream page on every launch.
+      backgroundColor: '#f5f2ed',
       webPreferences: {
         contextIsolation: true,
         nodeIntegration: false,
@@ -114,7 +156,7 @@ async function createWindow() {
       log(`render-process-gone: ${JSON.stringify(details)}`);
     });
 
-    mainWindow.loadURL(`http://127.0.0.1:${port}/`);
+    mainWindow.loadURL(`${APP_ORIGIN}/`);
 
     mainWindow.on('closed', () => {
       mainWindow = null;
@@ -126,6 +168,8 @@ async function createWindow() {
 
 app.whenReady().then(() => {
   log('app.whenReady resolved');
+  registerProtocolHandler();
+  log(`serving ${DIST_DIR} at ${APP_ORIGIN}/ (stable origin)`);
   createWindow();
 });
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -40,13 +40,14 @@
 // provide SPA-fallback routing, and `resolveRequest` below does that directly.
 'use strict';
 
-const { app, BrowserWindow, protocol, net } = require('electron');
+const { app, BrowserWindow, Menu, Tray, ipcMain, protocol, net, screen } = require('electron');
 const path = require('node:path');
 const fs = require('node:fs');
 const { pathToFileURL } = require('node:url');
 
 const DIST_DIR = path.join(__dirname, '..', 'dist');
 const ICON_PATH = path.join(__dirname, '..', 'resources', 'icon.ico');
+const WIDGET_PRELOAD = path.join(__dirname, 'widget-preload.cjs');
 
 const SCHEME = 'studydesk';
 const APP_ORIGIN = `${SCHEME}://app`;
@@ -166,11 +167,162 @@ function createWindow() {
   }
 }
 
+// ── glance widget (v1.11) ───────────────────────────────────────────────────
+//
+// A second, frameless, always-on-top window showing the next assignment due
+// and what is left of today. It runs its own renderer and its own Supabase
+// client rather than being fed over IPC, because the entire point is to be
+// readable with the main window closed — an IPC-tethered widget only has data
+// while the app is open, which is just the app in a smaller frame.
+//
+// That only works because both windows now share an origin (see the note at
+// the top of this file). Under the old random-port server there was no stable
+// origin, so the widget could never have seen the session at all.
+
+const WIDGET_SIZE = { width: 320, height: 200 };
+const BOUNDS_PATH = path.join(app.getPath('userData'), 'widget-bounds.json');
+
+let widgetWindow = null;
+let tray = null;
+
+// Position is persisted rather than the window being kept alive hidden. A
+// hidden window would leave the app running with nothing on screen, which is
+// how a tray app becomes a process the user cannot account for; destroying it
+// and remembering where it sat gets the same result with none of that.
+function readBounds() {
+  try {
+    const saved = JSON.parse(fs.readFileSync(BOUNDS_PATH, 'utf8'));
+    if (!Number.isFinite(saved.x) || !Number.isFinite(saved.y)) return null;
+    // A monitor that has since been unplugged would strand the widget
+    // off-screen, where it is both invisible and un-draggable.
+    const onScreen = screen.getAllDisplays().some((d) => {
+      const w = d.workArea;
+      return saved.x < w.x + w.width && saved.x + WIDGET_SIZE.width > w.x
+        && saved.y < w.y + w.height && saved.y + WIDGET_SIZE.height > w.y;
+    });
+    return onScreen ? { x: saved.x, y: saved.y } : null;
+  } catch {
+    return null;   // absent or corrupt — fall back to the default corner
+  }
+}
+
+function saveBounds() {
+  if (!widgetWindow || widgetWindow.isDestroyed()) return;
+  try {
+    const [x, y] = widgetWindow.getPosition();
+    fs.writeFileSync(BOUNDS_PATH, JSON.stringify({ x, y }));
+  } catch (err) {
+    log(`saveBounds failed: ${err && err.message}`);
+  }
+}
+
+function defaultBounds() {
+  // Bottom-right of the primary display's work area, inset by a comfortable
+  // margin — out of the way of whatever is being worked on, which is where a
+  // glance widget belongs.
+  const { workArea } = screen.getPrimaryDisplay();
+  return {
+    x: workArea.x + workArea.width - WIDGET_SIZE.width - 24,
+    y: workArea.y + workArea.height - WIDGET_SIZE.height - 24,
+  };
+}
+
+function createWidget() {
+  const pos = readBounds() || defaultBounds();
+  widgetWindow = new BrowserWindow({
+    ...WIDGET_SIZE,
+    ...pos,
+    frame: false,
+    resizable: false,
+    maximizable: false,
+    minimizable: false,
+    fullscreenable: false,
+    alwaysOnTop: true,
+    skipTaskbar: true,       // it is a widget, not a second app in the switcher
+    icon: ICON_PATH,
+    backgroundColor: '#faf8f4',   // --surface, so it opens as paper not white
+    webPreferences: {
+      preload: WIDGET_PRELOAD,
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+
+  // 'floating' keeps it above ordinary windows without fighting full-screen
+  // apps and system UI for the very top of the stack.
+  widgetWindow.setAlwaysOnTop(true, 'floating');
+  widgetWindow.on('moved', saveBounds);
+  widgetWindow.on('close', saveBounds);
+  widgetWindow.on('closed', () => { widgetWindow = null; refreshTrayMenu(); });
+  widgetWindow.webContents.on('did-fail-load', (_e, code, desc, url) => {
+    log(`widget did-fail-load: code=${code} desc=${desc} url=${url}`);
+  });
+  widgetWindow.webContents.on('did-finish-load', () => log('widget did-finish-load'));
+
+  widgetWindow.loadURL(`${APP_ORIGIN}/widget.html`);
+}
+
+function toggleWidget() {
+  if (widgetWindow && !widgetWindow.isDestroyed()) {
+    widgetWindow.close();
+    return;
+  }
+  createWidget();
+  refreshTrayMenu();
+}
+
+function openMainWindow() {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    if (mainWindow.isMinimized()) mainWindow.restore();
+    mainWindow.focus();
+    return;
+  }
+  createWindow();
+}
+
+// NOTE: these labels are English-only. The renderer is fully localised in ten
+// languages via i18next, but that lives in the renderer and the tray menu is
+// built in the main process, which has no translator. Logged as a known gap
+// rather than left to look intentional.
+function refreshTrayMenu() {
+  if (!tray) return;
+  tray.setContextMenu(Menu.buildFromTemplate([
+    {
+      label: 'Glance widget',
+      type: 'checkbox',
+      checked: Boolean(widgetWindow && !widgetWindow.isDestroyed()),
+      click: toggleWidget,
+    },
+    { label: 'Open StudyDesk', click: openMainWindow },
+    { type: 'separator' },
+    { label: 'Quit', click: () => app.quit() },
+  ]));
+}
+
+function createTray() {
+  try {
+    tray = new Tray(ICON_PATH);
+    tray.setToolTip('StudyDesk');
+    tray.on('double-click', openMainWindow);
+    refreshTrayMenu();
+  } catch (err) {
+    // A missing tray is a degraded app, not a broken one — the main window
+    // still works, so this must never take the launch down with it.
+    log(`createTray failed: ${err && err.stack}`);
+  }
+}
+
+ipcMain.on('widget:close', () => {
+  if (widgetWindow && !widgetWindow.isDestroyed()) widgetWindow.close();
+});
+
 app.whenReady().then(() => {
   log('app.whenReady resolved');
   registerProtocolHandler();
   log(`serving ${DIST_DIR} at ${APP_ORIGIN}/ (stable origin)`);
   createWindow();
+  createTray();
 });
 
 app.on('window-all-closed', () => {

--- a/electron/widget-preload.cjs
+++ b/electron/widget-preload.cjs
@@ -1,0 +1,17 @@
+// Preload for the glance widget window.
+//
+// The widget is frameless, so it has no system close button and the renderer
+// has to ask for one. With contextIsolation and sandbox on — which both stay
+// on — the renderer cannot reach Electron directly, so this exposes exactly
+// one verb over contextBridge and nothing else.
+//
+// Deliberately not a general IPC surface: the widget is read-only, and the
+// smallest possible bridge is the one least likely to become a way for page
+// content to drive the main process later.
+'use strict';
+
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('studydeskWidget', {
+  close: () => ipcRenderer.send('widget:close'),
+});

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -567,7 +567,8 @@
   },
   "widget": {
     "today": "اليوم",
-    "tomorrow": "غدًا"
+    "tomorrow": "غدًا",
+    "noPlanToday": "لا شيء مخطط اليوم"
   },
   "cal": {
     "title": "التقويم",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -547,7 +547,8 @@
   },
   "widget": {
     "today": "Heute",
-    "tomorrow": "Morgen"
+    "tomorrow": "Morgen",
+    "noPlanToday": "Heute nichts geplant"
   },
   "cal": {
     "title": "Kalender",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -547,7 +547,8 @@
   },
   "widget": {
     "today": "Today",
-    "tomorrow": "Tomorrow"
+    "tomorrow": "Tomorrow",
+    "noPlanToday": "Nothing planned today"
   },
   "cal": {
     "title": "Calendar",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -552,7 +552,8 @@
   },
   "widget": {
     "today": "Hoy",
-    "tomorrow": "Mañana"
+    "tomorrow": "Mañana",
+    "noPlanToday": "Nada planeado para hoy"
   },
   "cal": {
     "title": "Calendario",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -547,7 +547,8 @@
   },
   "widget": {
     "today": "Tänään",
-    "tomorrow": "Huomenna"
+    "tomorrow": "Huomenna",
+    "noPlanToday": "Ei suunnitelmia tänään"
   },
   "cal": {
     "title": "Kalenteri",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -552,7 +552,8 @@
   },
   "widget": {
     "today": "Aujourd’hui",
-    "tomorrow": "Demain"
+    "tomorrow": "Demain",
+    "noPlanToday": "Rien de prévu aujourd'hui"
   },
   "cal": {
     "title": "Calendrier",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -547,7 +547,8 @@
   },
   "widget": {
     "today": "आज",
-    "tomorrow": "कल"
+    "tomorrow": "कल",
+    "noPlanToday": "आज कुछ भी नियोजित नहीं"
   },
   "cal": {
     "title": "कैलेंडर",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -542,7 +542,8 @@
   },
   "widget": {
     "today": "Hari ini",
-    "tomorrow": "Besok"
+    "tomorrow": "Besok",
+    "noPlanToday": "Tidak ada rencana hari ini"
   },
   "cal": {
     "title": "Kalender",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -552,7 +552,8 @@
   },
   "widget": {
     "today": "Hoje",
-    "tomorrow": "Amanhã"
+    "tomorrow": "Amanhã",
+    "noPlanToday": "Nada planeado para hoje"
   },
   "cal": {
     "title": "Calendário",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -547,7 +547,8 @@
   },
   "widget": {
     "today": "今天",
-    "tomorrow": "明天"
+    "tomorrow": "明天",
+    "noPlanToday": "今天没有安排"
   },
   "cal": {
     "title": "日历",

--- a/src/styles/widget.css
+++ b/src/styles/widget.css
@@ -1,0 +1,273 @@
+/* Desktop glance widget — a 320×200 frameless always-on-top window.
+ *
+ * Reuses the app's tokens from base.css rather than redefining them, so the
+ * widget cannot drift off the cream-paper palette. base.css also supplies the
+ * paper-grain overlay on body::before, which is why this file never draws a
+ * texture of its own: the widget is a torn-off piece of the same sheet.
+ *
+ * Type sizes here are smaller than anywhere else in the app on purpose. This
+ * is a dial read at a glance from across a desk, not a screen to be worked in,
+ * so the ratio between the one serif statement and everything else is wider
+ * than the main UI would ever use.
+ */
+
+html, body, #root {
+  height: 100%;
+  overflow: hidden;             /* no scrollbars in a chrome-less 200px window */
+}
+
+.wg {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  /* The window has no frame, so this border IS the edge of the paper. Without
+     it the widget bleeds into whatever is behind it on a light desktop. */
+  border: 1px solid var(--border2);
+  color: var(--text);
+  user-select: none;            /* it is a readout; text selection is noise */
+}
+
+/* ── title bar / drag handle ─────────────────────────────────────────────── */
+
+.wg-bar {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 6px 0 12px;
+  height: 26px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  /* Frameless windows cannot be moved without an explicit drag region. This
+     strip is the only one — making the whole widget draggable would swallow
+     the close button's clicks on some platforms. */
+  -webkit-app-region: drag;
+}
+
+.wg-bar-date {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  color: var(--muted2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.wg-bar-close {
+  -webkit-app-region: no-drag;  /* or the button is a drag handle, not a button */
+  flex: none;
+  width: 20px;
+  height: 20px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  color: var(--muted2);
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 2px;
+  transition: background 0.12s var(--ease-paper), color 0.12s var(--ease-paper);
+}
+.wg-bar-close:hover { background: var(--surface2); color: var(--text); }
+.wg-bar-close:focus-visible { outline: 1px solid var(--muted2); outline-offset: 1px; }
+
+/* ── the one statement ───────────────────────────────────────────────────── */
+
+.wg-lead {
+  flex: none;
+  padding: 9px 12px 8px;
+  min-height: 0;
+}
+
+.wg-label {
+  font-family: var(--font-mono);
+  font-size: 8.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted2);
+  margin-bottom: 3px;
+}
+
+.wg-title {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 19px;
+  line-height: 1.16;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  /* Two lines, then ellipsis. A third line would push the plan out of the
+     window, and an assignment title long enough to need one is rare. */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.wg-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 5px;
+  font-size: 10px;
+  color: var(--muted);
+  min-width: 0;
+}
+
+.wg-course {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wg-dot {
+  flex: none;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--tick, var(--border2));
+}
+
+.wg-urgency {
+  flex: none;
+  margin-inline-start: auto;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.04em;
+  color: var(--muted2);
+}
+.wg-urgency.is-overdue {
+  color: var(--danger);
+  font-weight: 500;
+}
+
+.wg-quiet {
+  font-size: 11px;
+  color: var(--muted2);
+  padding: 2px 0;
+}
+.wg-quiet--plan { font-size: 10.5px; }
+
+/* ── rule ────────────────────────────────────────────────────────────────── */
+
+.wg-rule {
+  flex: none;
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: 0 12px;
+}
+
+/* ── the rest of today ───────────────────────────────────────────────────── */
+
+.wg-plan {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 8px 12px 10px;
+  overflow: hidden;
+}
+
+.wg-label--plan {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 5px;
+}
+
+.wg-more {
+  font-size: 8.5px;
+  letter-spacing: 0.06em;
+  color: var(--muted2);
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  padding: 0 3px;
+}
+
+.wg-rows {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+/* Everything already over: the whole block recedes rather than each row
+   fighting for the same attention as an upcoming one. */
+.wg-rows.is-spent { opacity: 0.7; }
+
+.wg-row {
+  display: grid;
+  grid-template-columns: 34px 2px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.wg-row-time {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--muted2);
+  font-variant-numeric: tabular-nums;
+}
+
+.wg-row-tick {
+  align-self: stretch;
+  min-height: 13px;
+  background: var(--tick, var(--border2));
+}
+/* A lesson is somewhere you have to be — solid. A planned block is a promise
+   to yourself — dashed. Same distinction the calendar already draws, so the
+   two surfaces teach the same vocabulary. */
+.wg-row-tick--planned {
+  background: repeating-linear-gradient(
+    to bottom,
+    var(--tick, var(--border2)) 0 3px,
+    transparent 3px 6px
+  );
+}
+
+.wg-row-body {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+}
+
+.wg-row-title {
+  font-size: 11px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wg-row-room {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--muted2);
+}
+
+.wg-row.is-past { opacity: 0.45; }
+.wg-row.is-done .wg-row-title { text-decoration: line-through; color: var(--muted2); }
+
+/* ── motion ──────────────────────────────────────────────────────────────── */
+/* One staged reveal on open, and nothing else. The widget is opened, read, and
+   ignored; anything that moves after that is movement in the corner of the
+   user's eye while they are trying to work. */
+
+@keyframes wg-settle {
+  from { opacity: 0; transform: translateY(3px); }
+  to   { opacity: 1; transform: none; }
+}
+
+.wg-lead, .wg-row {
+  animation: wg-settle 0.26s var(--ease-settle) both;
+}
+.wg-row { animation-delay: calc(60ms + var(--row-index, 0) * 45ms); }
+
+@media (prefers-reduced-motion: reduce) {
+  .wg-lead, .wg-row { animation: none; }
+  .wg-bar-close { transition: none; }
+}

--- a/src/widget/Widget.jsx
+++ b/src/widget/Widget.jsx
@@ -1,0 +1,148 @@
+// The desktop glance widget's one screen.
+//
+// Design intent: a torn slip off the desk pad, not a shrunken app window. At
+// 320×200 with no chrome there is room for exactly one statement and a short
+// list, so the composition is deliberately top-heavy — the next thing due gets
+// serif display type and the whole upper band, then a hairline rule, then the
+// rest of today in quiet mono. If you only ever read the top line, the widget
+// has done its job.
+//
+// Read-only by design. Every affordance that would change data lives in the
+// main window; this thing is a dial, not a control.
+
+import { useTranslation } from 'react-i18next';
+import { minutesToTime } from '../lib/timetable.js';
+import { fmtToday } from '../lib/dates.js';
+import { nextDue, todayPlan, visiblePlan, minutesOfDay } from './glance.js';
+import { useGlance } from './useGlance.js';
+import '../styles/base.css';
+import '../styles/widget.css';
+
+function closeWidget() {
+  // Exposed by electron/widget-preload.cjs. Optional-chained so the widget
+  // still renders in a plain browser tab during development, where there is no
+  // window to close.
+  window.studydeskWidget?.close();
+}
+
+/** Urgency copy, reusing the assignment view's existing ten-locale strings
+ *  rather than minting widget-only ones that would drift from them. */
+function urgencyLabel(t, daysAway) {
+  if (daysAway === null || daysAway === undefined) return null;
+  if (daysAway < 0) return t('av.urgency.overdue', { n: Math.abs(daysAway) });
+  if (daysAway === 0) return t('av.urgency.dueToday');
+  if (daysAway === 1) return t('av.urgency.dueTomorrow');
+  return t('av.urgency.daysLeft', { n: daysAway });
+}
+
+function PlanRow({ item, past, index }) {
+  const { t } = useTranslation();
+  const label = item.kind === 'lesson' ? t('tt.lesson') : t('cal.planned');
+  return (
+    <li
+      className={`wg-row${past ? ' is-past' : ''}${item.done ? ' is-done' : ''}`}
+      // Staggered only on first paint — see widget.css. Inline because the
+      // delay is per-row data, not a style rule.
+      style={{ '--row-index': index }}
+    >
+      <span className="wg-row-time">{minutesToTime(item.startMin)}</span>
+      <span
+        className={`wg-row-tick wg-row-tick--${item.kind}`}
+        style={item.color ? { '--tick': item.color } : undefined}
+        aria-hidden="true"
+      />
+      <span className="wg-row-body">
+        <span className="wg-row-title">{item.title || label}</span>
+        {item.room ? <span className="wg-row-room">{item.room}</span> : null}
+      </span>
+    </li>
+  );
+}
+
+export default function Widget() {
+  const { t } = useTranslation();
+  const { status, state, todayIso, now } = useGlance();
+
+  const due = status === 'ready' && state ? nextDue(state, todayIso) : null;
+  const plan = status === 'ready' && state ? todayPlan(state, todayIso) : [];
+  const { items, overflow, spent } = visiblePlan(plan, minutesOfDay(now));
+
+  return (
+    <div className="wg">
+      {/* The only drag region. Frameless windows have no title bar, so without
+          this the widget could be shown but never moved off wherever it opened. */}
+      <header className="wg-bar">
+        <span className="wg-bar-date">{fmtToday(now)}</span>
+        <button
+          type="button"
+          className="wg-bar-close"
+          onClick={closeWidget}
+          aria-label={t('common.close', 'Close')}
+        >
+          ×
+        </button>
+      </header>
+
+      <section className="wg-lead">
+        {status === 'loading' && <p className="wg-quiet">…</p>}
+
+        {status === 'signedOut' && (
+          <p className="wg-quiet">{t('settings.signedOutLocal')}</p>
+        )}
+
+        {status === 'error' && (
+          <p className="wg-quiet">{t('common.errorGeneric', '—')}</p>
+        )}
+
+        {status === 'ready' && !due && (
+          <p className="wg-quiet">{t('av.pl.nothingDue')}</p>
+        )}
+
+        {status === 'ready' && due && (
+          <>
+            <p className="wg-label">{t('av.pl.next')}</p>
+            <h1 className="wg-title" title={due.title}>{due.title}</h1>
+            <p className="wg-meta">
+              {due.courseName && (
+                <>
+                  <span
+                    className="wg-dot"
+                    style={due.color ? { '--tick': due.color } : undefined}
+                    aria-hidden="true"
+                  />
+                  <span className="wg-course">{due.courseName}</span>
+                </>
+              )}
+              <span className={`wg-urgency${due.daysAway < 0 ? ' is-overdue' : ''}`}>
+                {urgencyLabel(t, due.daysAway)}
+              </span>
+            </p>
+          </>
+        )}
+      </section>
+
+      <hr className="wg-rule" />
+
+      <section className="wg-plan">
+        <p className="wg-label wg-label--plan">
+          {t('sv.todayHead')}
+          {overflow > 0 && <span className="wg-more">+{overflow}</span>}
+        </p>
+        {items.length === 0 ? (
+          <p className="wg-quiet wg-quiet--plan">{t('widget.noPlanToday')}</p>
+        ) : (
+          <ul className={`wg-rows${spent ? ' is-spent' : ''}`}>
+            {items.map((item, i) => (
+              <PlanRow
+                key={`${item.kind}:${item.id}`}
+                item={item}
+                index={i}
+                past={item.endMin <= minutesOfDay(now)}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/widget/glance.js
+++ b/src/widget/glance.js
@@ -1,0 +1,136 @@
+// Pure derivation for the desktop glance widget.
+//
+// Everything here is a function of (state, today, now) with no I/O, so the
+// widget's behaviour can be reasoned about and tested without an Electron
+// window or a network round trip.
+//
+// The one rule this file exists to honour: it DERIVES, it does not re-implement.
+// Which lessons apply on a given date is a genuinely subtle question — a
+// timetable can attach to a school year, a semester or a jakso, and the most
+// specific term that actually has entries for that weekday wins. That rule
+// lives in lessonsOn() and must keep living in exactly one place; a second copy
+// here would drift and the widget would quietly disagree with the calendar the
+// user is looking at in the main window.
+
+import { lessonsOn, dayAndMinuteOf } from '../lib/timetable.js';
+import { parseLocalDate } from '../lib/dates.js';
+
+/** Whole days from `fromIso` to `toIso`. Negative when `toIso` is in the past. */
+export function daysUntil(fromIso, toIso) {
+  const a = parseLocalDate(fromIso);
+  const b = parseLocalDate(toIso);
+  if (!a || !b || Number.isNaN(a.getTime()) || Number.isNaN(b.getTime())) return null;
+  // Compare at local midnight so a due date is never off by one across a DST
+  // boundary, where a naive 86_400_000 division lands on 0.958 or 1.042 days.
+  const days = Math.round((b.getTime() - a.getTime()) / 86400000);
+  return days;
+}
+
+/**
+ * The single assignment the widget leads with: the soonest still-open one.
+ * Overdue work sorts first naturally, which is the right answer — a thing you
+ * have already missed outranks a thing due later today.
+ */
+export function nextDue(state, todayIso) {
+  const open = (state.assignments || []).filter((a) => a && !a.done && a.dueDate);
+  if (!open.length) return null;
+
+  const soonest = open.reduce((best, a) => {
+    const c = String(a.dueDate).localeCompare(String(best.dueDate));
+    if (c !== 0) return c < 0 ? a : best;
+    // Same date: stable, name-ordered, so the widget doesn't reshuffle between
+    // polls when two things are due the same day.
+    return String(a.title || '').localeCompare(String(best.title || '')) < 0 ? a : best;
+  });
+
+  const course = soonest.courseId ? state.courses?.[soonest.courseId] : null;
+  const liveCourse = course && !course.deletedAt ? course : null;
+  return {
+    id: soonest.id,
+    title: soonest.title || '',
+    dueDate: soonest.dueDate,
+    daysAway: daysUntil(todayIso, soonest.dueDate),
+    courseName: liveCourse?.name || null,
+    color: liveCourse?.color || null,
+  };
+}
+
+/**
+ * Everything scheduled for `todayIso`, lessons and planned study blocks
+ * together, in clock order.
+ *
+ * Lessons and planned study stay distinguishable by `kind` rather than being
+ * flattened into one list of "events". They are different commitments — a
+ * lesson is somewhere you have to be, a planned block is work you promised
+ * yourself — and the calendar already draws that distinction, so the widget
+ * keeps it too.
+ */
+export function todayPlan(state, todayIso) {
+  const lessons = lessonsOn(state, todayIso).map((l) => ({
+    kind: 'lesson',
+    id: l.id,
+    startMin: l.startMin,
+    endMin: l.endMin,
+    title: l.title,
+    courseName: l.courseName,
+    color: l.color,
+    room: l.room,
+    done: false,
+  }));
+
+  const planned = [];
+  for (const p of state.plannedSessions || []) {
+    // A dismissed block is one the user explicitly waved off; it is not part of
+    // today's plan any more and showing it would be nagging, not glancing.
+    if (!p || p.deletedAt || p.dismissedAt) continue;
+    const at = dayAndMinuteOf(p.startsAt);
+    if (!at || at.iso !== todayIso) continue;
+
+    const course = p.subjectId ? state.courses?.[p.subjectId] : null;
+    const liveCourse = course && !course.deletedAt ? course : null;
+    const duration = Number(p.durationMinutes);
+    planned.push({
+      kind: 'planned',
+      id: p.id,
+      startMin: at.minutes,
+      endMin: at.minutes + (Number.isFinite(duration) ? duration : 0),
+      title: p.title || liveCourse?.name || null,
+      courseName: liveCourse?.name || null,
+      color: liveCourse?.color || null,
+      room: null,
+      // Fulfilled means a real study session was logged against this block.
+      done: Boolean(p.fulfilledBy),
+    });
+  }
+
+  return [...lessons, ...planned].sort(
+    (a, b) => (a.startMin - b.startMin) || String(a.title || '').localeCompare(String(b.title || '')),
+  );
+}
+
+/**
+ * What the widget actually has room to show, given the clock.
+ *
+ * Forward-looking by default — the point of a glance is what is still coming.
+ * But when the day is over, falling back to the last couple of items is more
+ * honest than an empty state that reads "nothing planned today" at 23:00 on a
+ * day that had four lessons in it.
+ */
+export function visiblePlan(plan, nowMinutes, max = 4) {
+  if (!plan.length) return { items: [], overflow: 0, spent: false };
+
+  const upcoming = plan.filter((i) => i.endMin > nowMinutes);
+  if (upcoming.length) {
+    return {
+      items: upcoming.slice(0, max),
+      overflow: Math.max(0, upcoming.length - max),
+      spent: false,
+    };
+  }
+  return { items: plan.slice(-2), overflow: 0, spent: true };
+}
+
+/** Minutes past local midnight for `date`. */
+export function minutesOfDay(date) {
+  return date.getHours() * 60 + date.getMinutes();
+}

--- a/src/widget/main.jsx
+++ b/src/widget/main.jsx
@@ -1,0 +1,17 @@
+// Entry point for the desktop glance widget's own renderer.
+//
+// A second Vite entry rather than a route inside the main app: the widget is a
+// separate BrowserWindow with its own lifetime, and routing to it would mean
+// booting the entire app shell — reducer, sync engine, timer, notifications —
+// inside a 320×200 window that needs none of it.
+//
+// No <StrictMode>: its deliberate double-invoke of effects would double the
+// widget's poll on mount for no benefit here, and there is no component tree
+// to shake out bugs in — one screen, one hook.
+
+import { createRoot } from 'react-dom/client';
+import '../i18n';
+import '../index.css';
+import Widget from './Widget.jsx';
+
+createRoot(document.getElementById('root')).render(<Widget />);

--- a/src/widget/useGlance.js
+++ b/src/widget/useGlance.js
@@ -1,0 +1,140 @@
+// Data for the desktop glance widget.
+//
+// The widget runs its own Supabase client rather than being fed over IPC from
+// the main window, and that is the whole design. The value of a floating
+// widget is glancing at it WITHOUT the app open; an IPC-tethered one only has
+// data while the main window is alive, which makes it a small second copy of
+// the app rather than a glance.
+//
+// Sharing the session works because both windows are the same origin now
+// (studydesk://app — see electron/main.cjs). Before v1.11 the shell served
+// from a random port, so there was no stable origin to share and this could
+// not have worked at all.
+//
+// On running two Supabase clients against one stored session: this is the
+// ordinary multi-tab case, which supabase-js handles with the Web Locks API —
+// refreshes are serialised per origin, so the two windows cannot race each
+// other into burning the refresh-token chain. That failure mode is on record
+// in this suite (rapid reloads signing all three apps out at once), which is
+// why it is called out here rather than assumed away.
+//
+// Polling, not Realtime: "what is next" changes on the order of hours. A
+// subscription would hold a websocket open all day to deliver almost nothing.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { supabase } from '../lib/supabase.js';
+import { applyRemotePull } from '../lib/merge.js';
+import { toLocalISO } from '../lib/dates.js';
+
+const POLL_MS = 60_000;
+
+// applyRemotePull dereferences subjects/grades/sessions without a default, and
+// defaults the rest. Passing a complete shape keeps the widget honest about
+// what it did and did not ask the server for: an empty array here means "not
+// queried", not "none exist", and nothing in the widget reads those.
+const EMPTY_REMOTE = {
+  subjects: [], grades: [], sessions: [], assignments: [], exams: [],
+  actions: [], plannedSessions: [], academicTerms: [], timetableEntries: [],
+  attachments: [], commitments: [],
+};
+
+function dayBounds(now) {
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const end = new Date(start);
+  end.setDate(end.getDate() + 1);
+  return { start: start.toISOString(), end: end.toISOString() };
+}
+
+async function fetchGlance(now) {
+  const { start, end } = dayBounds(now);
+
+  // Five tables, not the eleven a full sync pulls. Terms and timetable entries
+  // come in whole because lesson resolution needs the term tree to decide which
+  // level's schedule wins; the other three are scoped.
+  //
+  // Assignments are NOT filtered on `done` server-side: a row where the column
+  // is null rather than false would drop out of `.eq('done', false)` and the
+  // widget would silently omit real homework. Filtering locally on Boolean()
+  // matches how the rest of the app reads that column.
+  const [subjects, assignments, planned, terms, timetable] = await Promise.all([
+    supabase.from('subjects').select('*'),
+    supabase.from('assignments').select('*'),
+    supabase.from('planned_sessions').select('*').gte('starts_at', start).lt('starts_at', end),
+    supabase.from('academic_terms').select('*'),
+    supabase.from('timetable_entries').select('*'),
+  ]);
+
+  for (const res of [subjects, assignments, planned, terms, timetable]) {
+    if (res.error) throw res.error;
+  }
+
+  return applyRemotePull({}, {
+    ...EMPTY_REMOTE,
+    subjects: subjects.data || [],
+    assignments: assignments.data || [],
+    plannedSessions: planned.data || [],
+    academicTerms: terms.data || [],
+    timetableEntries: timetable.data || [],
+  });
+}
+
+/**
+ * @returns {{status: 'loading'|'signedOut'|'error'|'ready', state: object|null,
+ *            todayIso: string, now: Date, refresh: () => void}}
+ */
+export function useGlance() {
+  const [status, setStatus] = useState('loading');
+  const [state, setState] = useState(null);
+  const [now, setNow] = useState(() => new Date());
+  const [signedIn, setSignedIn] = useState(null); // null = not yet resolved
+  const inFlight = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    supabase.auth.getSession().then(({ data }) => {
+      if (!cancelled) setSignedIn(Boolean(data?.session));
+    }).catch(() => {
+      if (!cancelled) setSignedIn(false);
+    });
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSignedIn(Boolean(session));
+    });
+    return () => { cancelled = true; sub?.subscription?.unsubscribe(); };
+  }, []);
+
+  const load = useCallback(async () => {
+    // A slow poll must not stack on itself. Without this a request that takes
+    // longer than the interval would queue another every 60s indefinitely.
+    if (inFlight.current) return;
+    inFlight.current = true;
+    const at = new Date();
+    try {
+      const next = await fetchGlance(at);
+      setState(next);
+      setNow(at);
+      setStatus('ready');
+    } catch {
+      // Keep whatever is on screen. A dropped Wi-Fi connection should leave the
+      // last known plan visible rather than blanking a widget the user glances
+      // at — the error state is only for when there is nothing to show yet.
+      setStatus((prev) => (prev === 'ready' ? 'ready' : 'error'));
+    } finally {
+      inFlight.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (signedIn === null) return;
+    if (!signedIn) { setStatus('signedOut'); setState(null); return; }
+
+    load();
+    const poll = setInterval(load, POLL_MS);
+    // The clock has to advance even when the data does not: "what is still to
+    // come" is a function of the time, so a widget left open past a lesson
+    // would otherwise keep showing it as upcoming until the next fetch.
+    const tick = setInterval(() => setNow(new Date()), 30_000);
+    return () => { clearInterval(poll); clearInterval(tick); };
+  }, [signedIn, load]);
+
+  return { status, state, todayIso: toLocalISO(now), now, refresh: load };
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,11 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// This config is ESM, so __dirname does not exist. The multi-entry input below
+// needs absolute paths.
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -11,5 +17,23 @@ export default defineConfig({
   // so the analytics import is compiled out of all three.
   define: {
     'import.meta.env.VITE_WEB_ANALYTICS': JSON.stringify(process.env.VERCEL === '1'),
+  },
+  build: {
+    rollupOptions: {
+      // Two entries: the app, and the desktop glance widget's own renderer
+      // (v1.11). The widget is a separate Electron BrowserWindow, so it needs
+      // its own HTML document — it is not a route inside the app.
+      //
+      // This ships widget.html in every build, including the Android one where
+      // nothing can open it. Measured before accepting: the widget's own entry
+      // chunk is small because React, i18next and supabase-js are already in
+      // shared chunks the app pulls anyway, so gating it out per-platform would
+      // buy back very little and cost a build-mode matrix where the desktop and
+      // web outputs differ.
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        widget: resolve(__dirname, 'widget.html'),
+      },
+    },
   },
 })

--- a/widget.html
+++ b/widget.html
@@ -1,0 +1,13 @@
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="/logo.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/fonts/fonts.css" />
+    <title>StudyDesk — Glance</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/widget/main.jsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
v1.11's anchor item, plus the prerequisite bug it turned up.

## 1. `fix(desktop)`: stable app origin

StudyDesk desktop signed the user out **on every launch**. Not an expiry — the shell served `dist/` from `server.listen(0, …)`, a random port, so the page had a different **origin** every launch, and localStorage (where supabase-js persists the session off-native) is partitioned per origin. Every launch opened an empty bucket.

NCC diagnosed and fixed exactly this in v1.10; the fix was never ported here. Confirmed on disk before changing anything: NCC's profile holds both an old `127.0.0.1:62320` bucket and the current `nexus://app`, while StudyDesk's held only `127.0.0.1:62769`.

Replaced with a registered `studydesk://` scheme — no port to collide, so the origin is stable by construction. Also fixes first paint: `backgroundColor` was `#0d1117`, NCC's dark surface, so a cream app flashed dark on every launch.

**Needs an owner action:** `studydesk://app/` must be added to Supabase's redirect-URL allowlist for the desktop build. The old random-port URLs could never be allowlisted, which is why OAuth was never usable on desktop.

## 2. `feat(desktop)`: the glance widget

Frameless, always-on-top, 320×200, tray-toggled, read-only. Own renderer, own Vite entry, own Supabase client — **not** IPC-fed, because a widget that only has data while the main window is alive is just the app in a smaller frame. That only works because of (1).

Two clients over one session is the ordinary multi-tab case, which supabase-js serialises via Web Locks, so they can't race into burning the refresh-token chain — called out in the source rather than assumed, given that failure mode is on record here.

It **derives, it does not re-implement**: term specificity is subtle, so it calls `lessonsOn()` and `applyRemotePull()` rather than keeping a second copy that would drift from the calendar.

## Verified

- **30 assertions** over the pure layer — DST-safe date maths, overdue outranking due-today, dismissed/deleted/other-day blocks dropping out, lessons outside the term range dropping out, spent-day fallback
- Rendered at 320×200 with fixtures: `scrollHeight == clientHeight == 200` (fits, no overflow), Playfair 19px, tokens correct, per-course tick colours, lesson tick solid vs planned dashed
- Ran in Electron: widget loads at `studydesk://app/widget.html`, no `did-fail-load`; move-then-close persisted `{"x":140,"y":96}`
- build + lint (`--max-warnings 0`) green; 0 `_vercel/insights` in `dist`

Second entry costs **10.2 kB raw / ~4 kB gzipped** (measured), since React/i18next/supabase-js are already shared chunks.

## Known gaps, stated rather than hidden

- **Tray labels are English only** — the renderer is fully localised, but the tray is built in the main process, which has no translator
- **Commitments aren't in "today's plan"** — the build plan named `timetable_entries` + `planned_sessions`; a day that omits an 18:00 training session is arguably incomplete, so this is a small follow-up worth taking
- **Live timer display** is out of scope by design (state is in localStorage, not Supabase) — see the plan doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)