### PR TITLE
Item 8: self-reported referral attribution (asked once per account)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import { supabase } from "./lib/supabase.js";
 import AuthGate from "./features/auth/AuthGate.jsx";
 import { isGuestMode, setGuestMode } from "./lib/guestMode.js";
 import { scheduleOriginStamp } from "./lib/originMarker.js";
+import ReferralPrompt from "./features/referral/ReferralPrompt.jsx";
 import { inheritFromNexus } from "./lib/suiteSso.js";
 import { hydrateOnboardedFromCloud, markOnboardedCloud } from "./lib/onboardingCloud.js";
 import * as sync from "./lib/sync.js";
@@ -1737,6 +1738,10 @@ export default function App() {
       />
     )}
     {flash&&<div className="flash">{flash}</div>}
+    {/* Item 8 — asks once per account, only inside the account-age window,
+        and only once onboarding is out of the way. Guests have no auth
+        metadata to write to, so `session?.user` is the whole gate. */}
+    {onboarded && session?.user && <ReferralPrompt user={session.user}/>}
   </>);
 }
 

--- a/src/features/referral/ReferralPrompt.jsx
+++ b/src/features/referral/ReferralPrompt.jsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { REFERRAL_OPTIONS, REFERRAL_DISMISSED, recordReferralSource, shouldAskReferral } from "../../lib/referralSource.js";
+
+// Item 8 — asks once, ever, then gets out of the way. See referralSource.js
+// for why this is self-reported and why it lives in auth metadata.
+//
+// Deliberately NOT a modal. This fires on a brand-new user's first real
+// session, which is precisely the moment activation is decided; a blocking
+// overlay demanding an answer before the app can be used would damage the
+// number it exists to measure. It is a corner card that can be ignored
+// outright — ignoring it still counts as dismissal once the card is closed.
+export default function ReferralPrompt({ user }) {
+  const { t } = useTranslation();
+  const [visible, setVisible] = useState(false);
+  const [closing, setClosing] = useState(false);
+
+  useEffect(() => {
+    if (!shouldAskReferral(user)) return;
+    // Short beat before appearing. On a fresh signup this mounts the instant
+    // onboarding finishes, and sliding a question in over the top of the
+    // completion frame reads as a second onboarding step rather than an
+    // aside — which is exactly what would make people answer at random.
+    const id = setTimeout(() => setVisible(true), 1200);
+    return () => clearTimeout(id);
+  }, [user]);
+
+  if (!visible) return null;
+
+  const answer = (source) => {
+    recordReferralSource(user, source);
+    // Leave the acknowledgement on screen briefly so the tap has a result;
+    // `closing` also disables the buttons, so a double-tap cannot fire a
+    // second write against the now-stale `hasReferralSource` read.
+    setClosing(true);
+    setTimeout(() => setVisible(false), 900);
+  };
+
+  return (
+    <div className="ref-card" role="dialog" aria-live="polite" aria-label={t("referral.title")}>
+      {closing ? (
+        <div className="ref-thanks">{t("referral.thanks")}</div>
+      ) : (
+        <>
+          <div className="ref-eyebrow">{t("referral.eyebrow")}</div>
+          <div className="ref-title">{t("referral.title")}</div>
+          <div className="ref-options">
+            {REFERRAL_OPTIONS.map((key) => (
+              <button key={key} type="button" className="ref-option" onClick={() => answer(key)}>
+                {t(`referral.opt.${key}`)}
+              </button>
+            ))}
+          </div>
+          <button type="button" className="ref-dismiss" onClick={() => answer(REFERRAL_DISMISSED)}>
+            {t("referral.dismiss")}
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -778,5 +778,17 @@
     "planSoonTitle": "فترة دراسة بعد {{n}} دقيقة",
     "planNowTitle": "فترة الدراسة تبدأ الآن",
     "planFallback": "جلسة دراسة"
+  },
+  "referral": {
+    "eyebrow": "سؤال واحد",
+    "title": "كيف عرفت StudyDesk؟",
+    "opt": {
+      "reddit": "Reddit",
+      "store": "أثناء التصفّح في F-Droid أو متجر تطبيقات",
+      "friend": "من صديق",
+      "other": "من مكان آخر"
+    },
+    "dismiss": "ليس الآن",
+    "thanks": "شكرًا — هذا يساعدنا."
   }
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -758,5 +758,17 @@
     "planSoonTitle": "Lernblock in {{n}} Min",
     "planNowTitle": "Lernblock beginnt jetzt",
     "planFallback": "Lernsitzung"
+  },
+  "referral": {
+    "eyebrow": "EINE FRAGE",
+    "title": "Woher kennst du StudyDesk?",
+    "opt": {
+      "reddit": "Reddit",
+      "store": "Beim Stöbern in F-Droid oder einem App-Store",
+      "friend": "Von Freunden",
+      "other": "Woanders"
+    },
+    "dismiss": "Nicht jetzt",
+    "thanks": "Danke – das hilft."
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -758,5 +758,17 @@
     "planSoonTitle": "Study block in {{n}} min",
     "planNowTitle": "Study block starting now",
     "planFallback": "Study session"
+  },
+  "referral": {
+    "eyebrow": "ONE QUESTION",
+    "title": "Where did you hear about StudyDesk?",
+    "opt": {
+      "reddit": "Reddit",
+      "store": "Browsing F-Droid or an app store",
+      "friend": "A friend",
+      "other": "Somewhere else"
+    },
+    "dismiss": "Not now",
+    "thanks": "Thanks — that helps."
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -763,5 +763,17 @@
     "planSoonTitle": "Bloque de estudio en {{n}} min",
     "planNowTitle": "El bloque de estudio empieza ahora",
     "planFallback": "Sesión de estudio"
+  },
+  "referral": {
+    "eyebrow": "UNA PREGUNTA",
+    "title": "¿Cómo conociste StudyDesk?",
+    "opt": {
+      "reddit": "Reddit",
+      "store": "Explorando F-Droid o una tienda de apps",
+      "friend": "Un amigo",
+      "other": "En otro sitio"
+    },
+    "dismiss": "Ahora no",
+    "thanks": "Gracias, nos ayuda."
   }
 }

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -758,5 +758,17 @@
     "planSoonTitle": "Opiskelujakso {{n}} min kuluttua",
     "planNowTitle": "Opiskelujakso alkaa nyt",
     "planFallback": "Opiskelujakso"
+  },
+  "referral": {
+    "eyebrow": "YKSI KYSYMYS",
+    "title": "Mistä kuulit StudyDeskistä?",
+    "opt": {
+      "reddit": "Reddit",
+      "store": "Selaillessa F-Droidia tai sovelluskauppaa",
+      "friend": "Kaverilta",
+      "other": "Jostain muualta"
+    },
+    "dismiss": "Ei nyt",
+    "thanks": "Kiitos – tästä on apua."
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -763,5 +763,17 @@
     "planSoonTitle": "Bloc de révision dans {{n}} min",
     "planNowTitle": "Le bloc de révision commence",
     "planFallback": "Session de révision"
+  },
+  "referral": {
+    "eyebrow": "UNE QUESTION",
+    "title": "Comment avez-vous connu StudyDesk ?",
+    "opt": {
+      "reddit": "Reddit",
+      "store": "En parcourant F-Droid ou un magasin d’applis",
+      "friend": "Un ami",
+      "other": "Ailleurs"
+    },
+    "dismiss": "Pas maintenant",
+    "thanks": "Merci, ça nous aide."
   }
 }

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -758,5 +758,17 @@
     "planSoonTitle": "{{n}} मिनट में अध्ययन ब्लॉक",
     "planNowTitle": "अध्ययन ब्लॉक अब शुरू",
     "planFallback": "अध्ययन सत्र"
+  },
+  "referral": {
+    "eyebrow": "एक सवाल",
+    "title": "आपने StudyDesk के बारे में कहाँ सुना?",
+    "opt": {
+      "reddit": "Reddit",
+      "store": "F-Droid या किसी ऐप स्टोर में ब्राउज़ करते हुए",
+      "friend": "किसी दोस्त से",
+      "other": "कहीं और"
+    },
+    "dismiss": "अभी नहीं",
+    "thanks": "धन्यवाद — इससे मदद मिलती है।"
   }
 }

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -753,5 +753,17 @@
     "planSoonTitle": "Blok belajar dalam {{n}} mnt",
     "planNowTitle": "Blok belajar dimulai sekarang",
     "planFallback": "Sesi belajar"
+  },
+  "referral": {
+    "eyebrow": "SATU PERTANYAAN",
+    "title": "Dari mana kamu tahu StudyDesk?",
+    "opt": {
+      "reddit": "Reddit",
+      "store": "Menjelajah F-Droid atau toko aplikasi",
+      "friend": "Dari teman",
+      "other": "Dari tempat lain"
+    },
+    "dismiss": "Nanti saja",
+    "thanks": "Terima kasih — ini membantu."
   }
 }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -763,5 +763,17 @@
     "planSoonTitle": "Bloco de estudo em {{n}} min",
     "planNowTitle": "O bloco de estudo começa agora",
     "planFallback": "Sessão de estudo"
+  },
+  "referral": {
+    "eyebrow": "UMA PERGUNTA",
+    "title": "Como você conheceu o StudyDesk?",
+    "opt": {
+      "reddit": "Reddit",
+      "store": "Navegando na F-Droid ou em uma loja de apps",
+      "friend": "Um amigo",
+      "other": "Em outro lugar"
+    },
+    "dismiss": "Agora não",
+    "thanks": "Obrigado — isso ajuda."
   }
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -758,5 +758,17 @@
     "planSoonTitle": "学习时段将在 {{n}} 分钟后开始",
     "planNowTitle": "学习时段现在开始",
     "planFallback": "学习时段"
+  },
+  "referral": {
+    "eyebrow": "一个问题",
+    "title": "你从哪里知道 StudyDesk 的？",
+    "opt": {
+      "reddit": "Reddit",
+      "store": "在 F-Droid 或应用商店里浏览时",
+      "friend": "朋友推荐",
+      "other": "其他地方"
+    },
+    "dismiss": "以后再说",
+    "thanks": "谢谢，这很有帮助。"
   }
 }

--- a/src/lib/referralSource.js
+++ b/src/lib/referralSource.js
@@ -1,0 +1,112 @@
+// Item 8 — self-reported referral attribution.
+//
+// WHY SELF-REPORTED AT ALL
+//
+// F-Droid has no install-referrer mechanism. Play Store has the Install
+// Referrer API; F-Droid has structurally nothing equivalent, and no UTM
+// scheme or redirect trick closes the gap — the chain breaks the moment
+// someone leaves the site to install. Vercel Analytics sees the web side
+// only. So the sole way to attribute an F-Droid install back to a specific
+// post is for the user to say so.
+//
+// SHAPE
+//
+// Reuses the `limecore_origin` mechanism exactly: one namespaced key in the
+// user's own auth metadata, written once, never overwritten. No table, no
+// column, no migration — clean against P1, nothing for an old build in the
+// wild to fail to understand.
+//
+// The suite wrinkle from originMarker.js applies here too and is, unusually,
+// a feature: the field lives on the shared auth user, so whichever suite app
+// asks first records the answer and the other two see it already present and
+// stay quiet. The user is asked once per account, not once per app.
+
+import { supabase } from "./supabase";
+import pkg from "../../package.json";
+
+const REFERRAL_KEY = "referral_source";
+
+// Kept broad on purpose. Cross-referencing a "reddit" answer against known
+// post dates identifies which post worked; asking the user to recall which
+// subreddit they were in would trade a reliable answer for an unreliable one.
+export const REFERRAL_OPTIONS = ["reddit", "store", "friend", "other"];
+
+// Written when the user dismisses instead of answering. A sentinel rather
+// than nothing, so "never shown again" survives a reinstall or a second
+// device — and so the data can tell "declined to say" apart from "never
+// asked", which are very different denominators.
+export const REFERRAL_DISMISSED = "dismissed";
+
+// Local mirror of the same fact. The metadata write is the durable record;
+// this is what stops a second prompt in the seconds before updateUser()
+// round-trips, and covers the case where that write fails outright.
+const ASKED_KEY = "sd-referral-asked";
+
+// Only ask accounts young enough that the answer is a memory rather than a
+// reconstruction. Without this gate every pre-existing account — 103 of them
+// predate the instrumentation — would be prompted on next open, and their
+// guesses would land in whatever week the prompt happened to ship, actively
+// corrupting the per-post attribution this exists to produce.
+const MAX_ACCOUNT_AGE_DAYS = 30;
+
+export function hasReferralSource(user) {
+  return Boolean(user?.user_metadata?.[REFERRAL_KEY]);
+}
+
+function askedLocally() {
+  try {
+    return localStorage.getItem(ASKED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function markAskedLocally() {
+  try {
+    localStorage.setItem(ASKED_KEY, "1");
+  } catch {
+    // Non-fatal. The metadata write is the real record; losing the local
+    // mirror costs at most one redundant prompt on this device.
+  }
+}
+
+function accountAgeDays(user) {
+  const created = user?.created_at ? Date.parse(user.created_at) : NaN;
+  if (Number.isNaN(created)) return Infinity;   // unknown age -> don't ask
+  return (Date.now() - created) / 86_400_000;
+}
+
+/** True when this signed-in user should see the prompt, exactly once, ever. */
+export function shouldAskReferral(user) {
+  if (!user) return false;                          // guests have no metadata
+  if (hasReferralSource(user)) return false;
+  if (askedLocally()) return false;
+  return accountAgeDays(user) <= MAX_ACCOUNT_AGE_DAYS;
+}
+
+/**
+ * Record the answer (or the dismissal) on the user, once.
+ *
+ * Fire-and-forget, like the origin stamp: attribution is not worth blocking
+ * or failing anything the user is actually trying to do. The local flag is
+ * set first and unconditionally, so a network failure costs the data point
+ * rather than producing a prompt that reappears until it succeeds.
+ */
+export function recordReferralSource(user, source) {
+  markAskedLocally();
+  if (!user || hasReferralSource(user)) return;
+  const value = {
+    source,
+    app: "studydesk",
+    app_version: pkg.version,
+    answered_at: new Date().toISOString(),
+  };
+  // Same deferral as scheduleOriginStamp: supabase-js holds an internal auth
+  // lock across onAuthStateChange callbacks, and this can be reached from a
+  // render triggered by one. Bouncing off the macrotask queue keeps it safe.
+  setTimeout(() => {
+    supabase.auth
+      .updateUser({ data: { [REFERRAL_KEY]: value } })
+      .catch((e) => console.warn("[studydesk] referral source write failed:", e));
+  }, 0);
+}

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -133,3 +133,28 @@
   .cdv-head{padding:14px;}
   .cdv-name{font-size:19px;}
 }
+
+/* ── Referral prompt (v1.11 Item 8) ────────────────────────────────────────
+   Corner card, not a modal — see ReferralPrompt.jsx for why. Sits where the
+   flash toast sits on desktop and clears the mobile tab bar the same way, so
+   it never covers navigation. Existing tokens only; nothing new is defined
+   here, so an alternate theme's token set restyles it for free. */
+.ref-card{position:fixed;bottom:24px;inset-inline-end:24px;z-index:210;width:300px;max-width:calc(100vw - 32px);
+  background:var(--surface);border:1px solid var(--border2);border-radius:6px;box-shadow:var(--shadow-md);
+  padding:16px 18px 14px;animation:fadeup 0.24s var(--ease-settle);}
+.ref-eyebrow{font-family:var(--font-mono);font-size:9px;letter-spacing:0.12em;text-transform:uppercase;color:var(--muted2);}
+.ref-title{font-family:var(--font-display);font-size:16px;line-height:1.3;margin:6px 0 12px;}
+.ref-options{display:flex;flex-direction:column;gap:6px;}
+.ref-option{text-align:start;font-family:var(--font-sans);font-size:13px;color:var(--text);
+  background:var(--bg);border:1px solid var(--border);border-radius:4px;padding:8px 11px;cursor:pointer;
+  transition:background 0.1s,border-color 0.1s;}
+.ref-option:hover{background:var(--surface2);border-color:var(--border2);}
+.ref-dismiss{display:block;margin:11px 0 0 auto;background:none;border:none;cursor:pointer;
+  font-family:var(--font-mono);font-size:10px;letter-spacing:0.06em;color:var(--muted);padding:2px 0;}
+.ref-dismiss:hover{color:var(--text);}
+.ref-thanks{font-family:var(--font-display);font-size:15px;padding:6px 0;}
+@media(max-width:768px){
+  /* Same clearance the flash toast uses, for the same reason: the bottom tab
+     bar plus the home-indicator inset. */
+  .ref-card{bottom:calc(72px + env(safe-area-inset-bottom));inset-inline-end:14px;inset-inline-start:14px;width:auto;}
+}


### PR DESCRIPTION
Closes the bottom half of attribution for **F-Droid**, which has no install-referrer mechanism at all — unlike Play Store's Install Referrer API, there is structurally nothing to read, and no UTM scheme survives the jump from the site to the installer. Vercel Analytics (Item 9) sees the web side only. The only remaining source of truth is the user.

## Shape

`referral_source` in the user's auth metadata, via the same mechanism as `limecore_origin` — written once, never overwritten. **No table, no column, no migration**, so there is nothing an already-installed build could fail to understand (`P1`).

Because the field lives on the shared auth user, whichever suite app asks first records the answer and the other two see it present and stay quiet. Asked once per *account*, not once per app.

## Two decisions worth reviewing

**Account-age gate (30 days).** Without it, every pre-existing account — the 103 that predate the instrumentation included — gets prompted on next open and answers from reconstruction rather than memory. That noise would land in whatever week the prompt happened to ship and would corrupt the per-post attribution this feature exists to produce. The gate is the difference between a usable number and a misleading one.

**Not a modal.** This fires on a brand-new user's first real session, which is exactly the moment activation is decided. A blocking overlay demanding an answer before the app can be used would damage the number it is measuring. It is a corner card, positioned where the flash toast sits, that clears the mobile tab bar and can be ignored outright.

**Dismissal writes a `dismissed` sentinel** rather than nothing — so "never shown again" survives a reinstall or a second device, and the data can distinguish *declined to say* from *never asked*, which are very different denominators.

## Verified

- `npm run build` and `npm run lint --max-warnings 0` both clean.
- `created_at` confirmed present and non-optional on the supabase-js `User` type (checked the shipped `.d.ts`, not assumed) — the age gate reads a real field.
- Card rendered against the real `base.css` / `cards.css` token set: Playfair title, DM Mono eyebrow, cream surface. New CSS defines no new tokens, so an alternate theme's token set restyles it for free.
- Strings in all 10 locales; locale diffs are +12 lines each, no reformatting.

NCC and LimeLog inherit the same module next, per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)