### PR TITLE
fix(desktop): refuse Google sign-in when the loopback listener never bound

### DIFF
--- a/src/features/auth/AuthGate.jsx
+++ b/src/features/auth/AuthGate.jsx
@@ -4,7 +4,7 @@ import { Capacitor } from '@capacitor/core';
 import { Browser } from '@capacitor/browser';
 import { App as CapApp } from '@capacitor/app';
 import { supabase, OAUTH_REDIRECT_URL } from '../../lib/supabase.js';
-import { desktop } from '../../lib/desktop.js';
+import { desktop, DESKTOP_REDIRECT_URL } from '../../lib/desktop.js';
 import { inheritFromNexus } from '../../lib/suiteSso.js';
 import { setGuestMode } from '../../lib/guestMode.js';
 import { translateAuthError } from '../../lib/authErrors.js';
@@ -346,7 +346,30 @@ export default function AuthGate() {
   }
 
   async function onGoogle() {
-    setErr(''); setInfo(''); setLoading(true);
+    setErr(''); setInfo('');
+    // Desktop with no loopback listener: every candidate port was taken at
+    // launch, so DESKTOP_REDIRECT_URL is null and OAUTH_REDIRECT_URL has fallen
+    // back to `${window.location.origin}/` — on desktop that is
+    // `studydesk://app/`, the exact value this release exists to stop sending
+    // to Supabase. Left alone the round trip still LOOKS like it works: the
+    // browser opens, Google authenticates, Supabase rejects a redirect target
+    // it cannot hold in its allow-list and falls back to the Site URL, and the
+    // user lands on limecore.dev/confirmed with no session and no error — while
+    // this screen sits on the "finish in your browser" notice waiting for a
+    // callback that can never arrive. `hardenNavigation` means the window is no
+    // longer hijacked, so it is a dead end rather than a brick, but a dead end
+    // with nothing attached to explain it.
+    //
+    // Refuse up front and name the remedy. Five ports must be simultaneously
+    // occupied for this to fire, so it is narrow by construction — and email
+    // sign-in needs no redirect, so the user still has a way in.
+    //
+    // Ported from NCC, where this gap was caught first.
+    if (desktop && !DESKTOP_REDIRECT_URL) {
+      setErr(t('auth.errDesktopNoListener'));
+      return;
+    }
+    setLoading(true);
     try {
       const { data, error } = await supabase.auth.signInWithOAuth({
         provider: 'google',

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -29,6 +29,7 @@
     "errGoogleStart": "تعذّر بدء تسجيل الدخول عبر Google",
     "errGoogleFailed": "فشل تسجيل الدخول عبر Google",
     "desktopBrowser": "أكمل تسجيل الدخول في المتصفح ثم عد إلى هنا.",
+    "errDesktopNoListener": "تسجيل الدخول من سطح المكتب غير متاح في هذه الجلسة. أعد تشغيل StudyDesk أو سجّل الدخول بالبريد الإلكتروني أدناه.",
     "errCallback": "فشل استدعاء العودة لتسجيل الدخول",
     "errGeneric": "فشل المصادقة",
     "errInvalidCredentials": "البريد الإلكتروني أو كلمة المرور غير صحيحة.",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -105,6 +105,7 @@
     "errGoogleStart": "Google-Anmeldung konnte nicht gestartet werden",
     "errGoogleFailed": "Google-Anmeldung fehlgeschlagen",
     "desktopBrowser": "Schließe die Anmeldung im Browser ab und komm dann hierher zurück.",
+    "errDesktopNoListener": "Die Desktop-Anmeldung ist bei diesem Start nicht verfügbar. Starte StudyDesk neu oder melde dich unten per E-Mail an.",
     "errCallback": "Anmelde-Rückruf fehlgeschlagen",
     "errGeneric": "Authentifizierung fehlgeschlagen",
     "errInvalidCredentials": "E-Mail oder Passwort ist falsch.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -105,6 +105,7 @@
     "errGoogleStart": "Failed to start Google sign-in",
     "errGoogleFailed": "Google sign-in failed",
     "desktopBrowser": "Finish signing in in your browser, then come back here.",
+    "errDesktopNoListener": "Desktop sign-in is unavailable this launch. Restart StudyDesk, or sign in with email below.",
     "errCallback": "Sign-in callback failed",
     "errGeneric": "Authentication failed",
     "errInvalidCredentials": "Incorrect email or password.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -106,6 +106,7 @@
     "errGoogleStart": "No se pudo iniciar el acceso con Google",
     "errGoogleFailed": "Error al iniciar sesión con Google",
     "desktopBrowser": "Termina de iniciar sesión en tu navegador y vuelve aquí.",
+    "errDesktopNoListener": "El inicio de sesión de escritorio no está disponible en este arranque. Reinicia StudyDesk o inicia sesión con correo abajo.",
     "errCallback": "Error en la respuesta de inicio de sesión",
     "errGeneric": "Error de autenticación",
     "errInvalidCredentials": "Correo o contraseña incorrectos.",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -105,6 +105,7 @@
     "errGoogleStart": "Google-kirjautumisen aloitus epäonnistui",
     "errGoogleFailed": "Google-kirjautuminen epäonnistui",
     "desktopBrowser": "Viimeistele kirjautuminen selaimessa ja palaa tänne.",
+    "errDesktopNoListener": "Työpöytäkirjautuminen ei ole käytettävissä tällä käynnistyskerralla. Käynnistä StudyDesk uudelleen tai kirjaudu sähköpostilla alta.",
     "errCallback": "Kirjautumisen paluukutsu epäonnistui",
     "errGeneric": "Todennus epäonnistui",
     "errInvalidCredentials": "Väärä sähköposti tai salasana.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -106,6 +106,7 @@
     "errGoogleStart": "Impossible de démarrer la connexion Google",
     "errGoogleFailed": "Échec de la connexion Google",
     "desktopBrowser": "Terminez la connexion dans votre navigateur, puis revenez ici.",
+    "errDesktopNoListener": "La connexion sur ordinateur est indisponible pour ce lancement. Redémarrez StudyDesk ou connectez-vous par e-mail ci-dessous.",
     "errCallback": "Échec du rappel de connexion",
     "errGeneric": "Échec de l'authentification",
     "errInvalidCredentials": "E-mail ou mot de passe incorrect.",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -29,6 +29,7 @@
     "errGoogleStart": "Google साइन-इन शुरू नहीं हो सका",
     "errGoogleFailed": "Google साइन-इन विफल",
     "desktopBrowser": "अपने ब्राउज़र में साइन-इन पूरा करें, फिर यहाँ लौटें।",
+    "errDesktopNoListener": "इस बार डेस्कटॉप साइन-इन उपलब्ध नहीं है। StudyDesk को पुनः प्रारंभ करें, या नीचे ईमेल से साइन इन करें।",
     "errCallback": "साइन-इन कॉलबैक विफल",
     "errGeneric": "प्रमाणीकरण विफल",
     "errInvalidCredentials": "ईमेल या पासवर्ड ग़लत है।",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -29,6 +29,7 @@
     "errGoogleStart": "Tidak dapat memulai proses masuk dengan Google",
     "errGoogleFailed": "Gagal masuk dengan Google",
     "desktopBrowser": "Selesaikan proses masuk di peramban, lalu kembali ke sini.",
+    "errDesktopNoListener": "Masuk lewat desktop tidak tersedia pada peluncuran ini. Mulai ulang StudyDesk, atau masuk dengan email di bawah.",
     "errCallback": "Callback proses masuk gagal",
     "errGeneric": "Autentikasi gagal",
     "errInvalidCredentials": "Email atau kata sandi salah.",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -29,6 +29,7 @@
     "errGoogleStart": "Não foi possível iniciar o login com o Google",
     "errGoogleFailed": "Falha no login com o Google",
     "desktopBrowser": "Conclua o login no seu navegador e volte para cá.",
+    "errDesktopNoListener": "O login no computador está indisponível nesta inicialização. Reinicie o StudyDesk ou entre com e-mail abaixo.",
     "errCallback": "Falha no retorno do login",
     "errGeneric": "Falha na autenticação",
     "errInvalidCredentials": "E-mail ou senha incorretos.",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -105,6 +105,7 @@
     "errGoogleStart": "无法启动 Google 登录",
     "errGoogleFailed": "Google 登录失败",
     "desktopBrowser": "请在浏览器中完成登录，然后回到这里。",
+    "errDesktopNoListener": "本次启动无法使用桌面登录。请重启 StudyDesk，或在下方使用邮箱登录。",
     "errCallback": "登录回调失败",
     "errGeneric": "身份验证失败",
     "errInvalidCredentials": "邮箱或密码不正确。",


### PR DESCRIPTION
Follow-up to #46, which is merged — this is a fresh change off `main`, not a reopen. It ports a guard that [Limekana/nexus-command-center#35](https://github.com/Limekana/nexus-command-center/pull/35) caught first, into the identical gap here. One file plus ten locale strings; no version bump, no schema change.

## The gap #46 left

`DESKTOP_REDIRECT_URL` is null when all five candidate ports were taken at launch. `OAUTH_REDIRECT_URL` then falls back to `` `${window.location.origin}/` `` — which on desktop is `studydesk://app/`, **the exact value #46 exists to stop sending to Supabase.**

I wrote that fallback deliberately and reasoned about it in a comment as "no worse than what shipped." That was wrong in the way that matters: it is not worse, but it fails *silently and misleadingly*.

The browser opens. Google authenticates. Supabase rejects a redirect target it cannot hold in its allow-list, falls back to the Site URL, and the user lands on `limecore.dev/confirmed` with no session and no error. Meanwhile the sign-in screen sits on the "Finish signing in in your browser" notice, waiting for a callback that can never arrive.

`hardenNavigation()` means the app's own window is no longer hijacked, so this is a dead end rather than a brick. But it's a dead end with nothing attached to explain it — and it produces exactly the support report that has no information in it.

## The fix

Refuse up front, and name the remedy:

```jsx
if (desktop && !DESKTOP_REDIRECT_URL) {
  setErr(t('auth.errDesktopNoListener'));
  return;
}
```

> Desktop sign-in is unavailable this launch. Restart StudyDesk, or sign in with email below.

Email sign-in needs no redirect and is untouched, so the user still has a way in. Narrow by construction — five ports must be simultaneously occupied for this to fire — so it costs one comparison on a path that is already doing network I/O.

`errDesktopNoListener` added to all ten locales, placed next to `desktopBrowser`, the notice this is the failure counterpart to.

## Verified

Real Electron launch, with all five ports (51837–51841) held open by a separate process so the listener genuinely could not bind:

```
blocked ports: 51837,51838,51839,51840,51841
bridge: {"present":true,"redirectUri":null}   (redirectUri null = listener never bound)
opened in system browser: []
window url: studydesk://app/ (unchanged)
on-screen: Desktop sign-in is unavailable this launch. Restart StudyDesk, or sign in with email below.
```

Nothing is launched, and the message says what to do. Before this change the same run would have opened the browser with `redirect_to=studydesk://app/` and dead-ended.

Regression check with the ports free — the happy path is unchanged:

```
opened in system browser: https://hkktorzhaqnfqsnlstda.supabase.co/auth/v1/authorize?provider=google
                          &redirect_to=http%3A%2F%2F127.0.0.1%3A51837%2Fcallback&code_challenge=…
on-screen notice: Finish signing in in your browser, then come back here.
```

## Still outstanding from #46

The Supabase redirect allow-list entries are still an owner action, and desktop Google sign-in stays broken until they exist — ports 51837–51841, path `/callback`, under **Auth → URL Configuration → Redirect URLs**. This PR changes nothing about that; it only stops the *no-listener* case from failing quietly.

## Gates

`npm run lint` · `npm run check:ime` · `npm run check:secrets` · `npm run build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Y4Nj78g9fh4H2KVdcpVth

---
_Generated by [Claude Code](https://claude.ai/code/session_012Y4Nj78g9fh4H2KVdcpVth)_